### PR TITLE
Right click to harvest, Block Nether Roof Building, Spawner place permission, More dispenser behavior, Invisible Item frames

### DIFF
--- a/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
@@ -48,7 +48,15 @@ public class PurpurConfig {
 
         enableFeature(ChorusFlowerListener.class, getBoolean("settings.blocks.chorus-flowers-always-drop", false));
 
+        enableFeature(SpawnerPlacementListener.class, getBoolean("settings.blocks.use-spawner-placement-permission", false));
+
+        enableFeature(NetherRoofBuildListener.class, getBoolean("settings.blocks.prevent-building-above-nether", false));
+
         enableFeature(RespawnAnchorNeedsChargeListener.class, !getBoolean("settings.gameplay-settings.respawn-anchor-needs-charges", true));
+
+        enableFeature(FarmingListener.class, getBoolean("settings.gameplay-settings.right-click-autoreplant", false));
+
+        enableFeature(ItemFrameListener.class, getBoolean("settings.blocks.shift-right-click-for-invisible-item-frames", false));
 
         enableFeature(EscapeCommandSlashListener.class, getBoolean("settings.chat.escape-commands", false));
 
@@ -61,9 +69,8 @@ public class PurpurConfig {
 
         enableFeature(MobNoTargetListener.class, getBoolean("settings.use-notarget-permissions", false));
 
+
         enableFeature(BossBarListener.class, getBoolean("settings.dye-boss-bars", false));
-
-
 
         boolean lightningTransformEntities = getBoolean("settings.lightning-transforms-entities.enabled", false);
         handleLightningTransformedEntities(lightningTransformEntities);

--- a/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
@@ -52,6 +52,8 @@ public class PurpurConfig {
 
         enableFeature(NetherRoofBuildListener.class, getBoolean("settings.blocks.prevent-building-above-nether", false));
 
+        enableFeature(DispenserCauldronListener.class, getBoolean("settings.blocks.dispense-filled-buckets-in-cauldrons", false));
+
         enableFeature(RespawnAnchorNeedsChargeListener.class, !getBoolean("settings.gameplay-settings.respawn-anchor-needs-charges", true));
 
         enableFeature(FarmingListener.class, getBoolean("settings.gameplay-settings.right-click-autoreplant", false));

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/DispenserCauldronListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/DispenserCauldronListener.java
@@ -8,7 +8,6 @@ import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
@@ -16,10 +15,17 @@ import java.util.List;
 
 public class DispenserCauldronListener implements Listener {
     //I know there's already a dispenser listener that listens for this event but I couldn't figure out how on earth to put it in without messing it up :D
+    BlockData waterCauldron = Bukkit.createBlockData(Material.WATER_CAULDRON, blockData -> {
+        Levelled cauldron = (Levelled) blockData;
+        cauldron.setLevel(3);
+    });
+    BlockData powderSnowCauldron = Bukkit.createBlockData(Material.POWDER_SNOW_CAULDRON, blockData -> {
+        Levelled cauldron = (Levelled) blockData;
+        cauldron.setLevel(3);
+    });
+    BlockData lavaCauldron = Bukkit.createBlockData(Material.LAVA_CAULDRON);
     List<Material> cauldronTypes = Arrays.asList(Material.CAULDRON, Material.LAVA_CAULDRON, Material.WATER_CAULDRON, Material.POWDER_SNOW_CAULDRON);
     List<Material> bucketTypes = Arrays.asList(Material.BUCKET, Material.LAVA_BUCKET, Material.WATER_BUCKET, Material.POWDER_SNOW_BUCKET);
-    SoundCategory blockSound = SoundCategory.BLOCKS;
-    Sound dispenseSound = Sound.BLOCK_DISPENSER_DISPENSE;
 
     @EventHandler
     public void onPreDispense(BlockPreDispenseEvent event) {
@@ -27,138 +33,83 @@ public class DispenserCauldronListener implements Listener {
         Dispenser dispenser = (Dispenser) event.getBlock().getBlockData();
         org.bukkit.block.Dispenser blockDispenser = (org.bukkit.block.Dispenser) event.getBlock().getState(false);
         Block block = event.getBlock().getRelative(dispenser.getFacing());
-        Inventory dispenserInventory = blockDispenser.getInventory();
-        int emptySlot = dispenserInventory.firstEmpty();
-        Levelled cauldronBlock;
-        BlockData waterCauldron = Bukkit.createBlockData(Material.WATER_CAULDRON, blockData -> {
-            Levelled cauldron = (Levelled) blockData;
-            cauldron.setLevel(3);
-        });
-        BlockData powderSnowCauldron = Bukkit.createBlockData(Material.POWDER_SNOW_CAULDRON, blockData -> {
-            Levelled cauldron = (Levelled) blockData;
-            cauldron.setLevel(3);
-        });
-        Location dispenserLocation = blockDispenser.getLocation();
-        Location cauldronLocation = block.getLocation();
-        Sound lavaDispense = Sound.ITEM_BUCKET_EMPTY_LAVA;
-        Sound lavaEmpty = Sound.ITEM_BUCKET_FILL_LAVA;
-        Sound waterDispense = Sound.ITEM_BUCKET_EMPTY;
-        Sound waterEmpty = Sound.ITEM_BUCKET_FILL;
-        Sound powderSnowDispense = Sound.ITEM_BUCKET_EMPTY_POWDER_SNOW;
-        Sound powderSnowEmpty = Sound.ITEM_BUCKET_FILL_POWDER_SNOW;
-        Material dispensedItemMaterial = event.getItemStack().getType();
-        ItemStack dispensedItem = event.getItemStack();
-        Material material = block.getType();
-
-        if(!(cauldronTypes.contains(block.getType()))) return;
-        if(!(bucketTypes.contains(dispensedItemMaterial))) return;
-        switch (material){
-            case CAULDRON:
-                if(dispensedItemMaterial.equals(Material.BUCKET)){
-                    return;
-                } else {
-                    switch (dispensedItemMaterial) {
-                        case LAVA_BUCKET -> {
-                            block.setType(Material.LAVA_CAULDRON);
-                            dispensedItem.setType(Material.BUCKET);
-                            playSounds(dispenserLocation, lavaDispense);
-                            event.setCancelled(true);
-                            return;
-                        }
-                        case WATER_BUCKET -> {
-                            block.setBlockData(waterCauldron);
-                            dispensedItem.setType(Material.BUCKET);
-                            playSounds(dispenserLocation, waterDispense);
-                            event.setCancelled(true);
-                            return;
-                        }
-                        case POWDER_SNOW_BUCKET -> {
-                            block.setBlockData(powderSnowCauldron);
-                            dispensedItem.setType(Material.BUCKET);
-                            playSounds(dispenserLocation, powderSnowDispense);
-                            event.setCancelled(true);
-                            return;
-                        }
-                    }
-                }
-
-            case LAVA_CAULDRON:
-                if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
-                block.setType(Material.CAULDRON);
-                if(dispensedItem.getAmount() > 1) {
-                    ItemStack lavaBucket = new ItemStack(Material.LAVA_BUCKET);
-                    dispensedItem.setAmount(dispensedItem.getAmount() - 1);
-                    if (emptySlot == -1) {
-                        block.getWorld().dropItem(cauldronLocation, lavaBucket);
-                        playSounds(dispenserLocation, lavaEmpty);
-                        event.setCancelled(true);
-                        return;
-                    }
-                    event.setCancelled(true);
-                    playSounds(dispenserLocation, lavaEmpty);
-                    blockDispenser.getInventory().setItem(emptySlot, lavaBucket);
-                    return;
-                }
+        ItemStack dispensedItems = event.getItemStack();
+        Material dispensedItemType = dispensedItems.getType();
+        Material blockType = block.getType();
+        Levelled cauldronLevel;
+        if(!cauldronTypes.contains(blockType)) return;
+        if(!bucketTypes.contains(dispensedItems.getType())) return;
+        if(block.getType().equals(Material.CAULDRON)){
+            if(dispensedItemType.equals(Material.BUCKET)) return;
+            if(dispensedItemType.equals(Material.LAVA_BUCKET)){
+                emptyCauldronHandler(block, lavaCauldron, dispensedItems, blockDispenser.getLocation(), Sound.ITEM_BUCKET_EMPTY_LAVA);
                 event.setCancelled(true);
-                playSounds(dispenserLocation, lavaEmpty);
-                dispensedItem.setType(Material.LAVA_BUCKET);
                 return;
-            case WATER_CAULDRON:
-                if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
-                cauldronBlock = (Levelled) block.getBlockData();
-                if(cauldronBlock.getLevel() < 3) {
-                    event.setCancelled(true);
-                    return;
-                }
-                block.setType(Material.CAULDRON);
-                if(dispensedItem.getAmount() > 1){
-                    ItemStack waterBucket = new ItemStack(Material.WATER_BUCKET);
-                    dispensedItem.setAmount(dispensedItem.getAmount() - 1);
-                    if(emptySlot == -1){
-                        block.getWorld().dropItem(cauldronLocation, waterBucket);
-                        playSounds(dispenserLocation, waterEmpty);
-                        event.setCancelled(true);
-                        return;
-                    }
-                    event.setCancelled(true);
-                    playSounds(dispenserLocation, waterEmpty);
-                    blockDispenser.getInventory().setItem(emptySlot, waterBucket);
-                    return;
-                }
+            }
+            if (dispensedItemType.equals(Material.WATER_BUCKET)){
+                emptyCauldronHandler(block, waterCauldron, dispensedItems, blockDispenser.getLocation(), Sound.ITEM_BUCKET_EMPTY);
                 event.setCancelled(true);
-                playSounds(dispenserLocation, waterEmpty);
-                dispensedItem.setType(Material.WATER_BUCKET);
                 return;
-            case POWDER_SNOW_CAULDRON:
-                if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
-                cauldronBlock = (Levelled) block.getBlockData();
-                if(cauldronBlock.getLevel() < 3) {
-                    event.setCancelled(true);
-                    return;
-                }
-                block.setType(Material.CAULDRON);
-                if(dispensedItem.getAmount() > 1){
-                    ItemStack powderSnowBucket = new ItemStack(Material.POWDER_SNOW_BUCKET);
-                    dispensedItem.setAmount(dispensedItem.getAmount() - 1);
-                    if(emptySlot == -1){
-                        block.getWorld().dropItem(cauldronLocation, powderSnowBucket);
-                        playSounds(dispenserLocation, powderSnowEmpty);
-                        event.setCancelled(true);
-                        return;
-                    }
-                    event.setCancelled(true);
-                    playSounds(dispenserLocation, powderSnowEmpty);
-                    blockDispenser.getInventory().setItem(emptySlot, powderSnowBucket);
-                    return;
-                }
+            }
+            if(dispensedItemType.equals(Material.POWDER_SNOW_BUCKET)){
+                emptyCauldronHandler(block, powderSnowCauldron, dispensedItems, blockDispenser.getLocation(), Sound.ITEM_BUCKET_EMPTY_POWDER_SNOW);
                 event.setCancelled(true);
-                playSounds(dispenserLocation, powderSnowEmpty);
-                dispensedItem.setType(Material.POWDER_SNOW_BUCKET);
+                return;
+            }
+        }
+        if(!dispensedItemType.equals(Material.BUCKET)) return;
+        if(block.getType().equals(Material.LAVA_CAULDRON)){
+            fullCauldronHandler(block, dispensedItems, blockDispenser, Material.LAVA_BUCKET, Sound.ITEM_BUCKET_FILL_LAVA);
+            event.setCancelled(true);
+            return;
+        }
+        if(block.getType().equals(Material.WATER_CAULDRON)){
+            cauldronLevel = (Levelled) block.getBlockData();
+            if (cauldronLevel.getLevel() < 3) return;
+            fullCauldronHandler(block, dispensedItems, blockDispenser, Material.WATER_BUCKET, Sound.ITEM_BUCKET_FILL);
+            event.setCancelled(true);
+            return;
+        }
+        if(block.getType().equals(Material.POWDER_SNOW_CAULDRON)){
+            cauldronLevel = (Levelled) block.getBlockData();
+            if (cauldronLevel.getLevel() < 3) return;
+            fullCauldronHandler(block, dispensedItems, blockDispenser, Material.POWDER_SNOW_BUCKET, Sound.ITEM_BUCKET_FILL_POWDER_SNOW);
+            event.setCancelled(true);
         }
     }
-    public void playSounds(Location dLoc, Sound actionSound){
-        dLoc.getWorld().playSound(dLoc, dispenseSound, blockSound, 1, 1);
-        dLoc.getWorld().playSound(dLoc, actionSound, blockSound, 1, 1);
+
+    public void emptyCauldronHandler(Block cauldron,
+                                     BlockData cauldronType,
+                                     ItemStack dispensingItem,
+                                     Location dispLocation,
+                                     Sound uniqueSound){
+        cauldron.setBlockData(cauldronType);
+        dispensingItem.setType(Material.BUCKET);
+        dispLocation.getWorld().playSound(dispLocation, Sound.BLOCK_DISPENSER_DISPENSE, SoundCategory.BLOCKS, 1, 1);
+        dispLocation.getWorld().playSound(dispLocation, uniqueSound, SoundCategory.BLOCKS, 1, 1);
+    }
+
+    public void fullCauldronHandler(Block cauldron,
+                                    ItemStack items,
+                                    org.bukkit.block.Dispenser dispenserBlock,
+                                    Material newItem,
+                                    Sound uniqueSound){
+        cauldron.setType(Material.CAULDRON);
+        ItemStack newItemDrop = new ItemStack(newItem);
+        int emptySlot = dispenserBlock.getInventory().firstEmpty();
+        if(items.getAmount() > 1){
+            items.setAmount(items.getAmount() - 1);
+            if(emptySlot == -1){
+                cauldron.getWorld().dropItem(cauldron.getLocation(), newItemDrop);
+            } else {
+                dispenserBlock.getInventory().setItem(emptySlot, newItemDrop);
+            }
+        } else {
+            items.setType(newItem);
+        }
+        dispenserBlock.getWorld().playSound(dispenserBlock.getLocation(), Sound.BLOCK_DISPENSER_DISPENSE, SoundCategory.BLOCKS, 1, 1);
+        dispenserBlock.getWorld().playSound(dispenserBlock.getLocation(), uniqueSound, SoundCategory.BLOCKS, 1, 1);
     }
 }
+
 

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/DispenserCauldronListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/DispenserCauldronListener.java
@@ -1,0 +1,164 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import io.papermc.paper.event.block.BlockPreDispenseEvent;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Levelled;
+import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DispenserCauldronListener implements Listener {
+    //I know there's already a dispenser listener that listens for this event but I couldn't figure out how on earth to put it in without messing it up :D
+    List<Material> cauldronTypes = Arrays.asList(Material.CAULDRON, Material.LAVA_CAULDRON, Material.WATER_CAULDRON, Material.POWDER_SNOW_CAULDRON);
+    List<Material> bucketTypes = Arrays.asList(Material.BUCKET, Material.LAVA_BUCKET, Material.WATER_BUCKET, Material.POWDER_SNOW_BUCKET);
+    SoundCategory blockSound = SoundCategory.BLOCKS;
+    Sound dispenseSound = Sound.BLOCK_DISPENSER_DISPENSE;
+
+    @EventHandler
+    public void onPreDispense(BlockPreDispenseEvent event) {
+        if (!event.getBlock().getType().equals(Material.DISPENSER)) return;
+        Dispenser dispenser = (Dispenser) event.getBlock().getBlockData();
+        org.bukkit.block.Dispenser blockDispenser = (org.bukkit.block.Dispenser) event.getBlock().getState(false);
+        Block block = event.getBlock().getRelative(dispenser.getFacing());
+        Inventory dispenserInventory = blockDispenser.getInventory();
+        int emptySlot = dispenserInventory.firstEmpty();
+        Levelled cauldronBlock;
+        BlockData waterCauldron = Bukkit.createBlockData(Material.WATER_CAULDRON, blockData -> {
+            Levelled cauldron = (Levelled) blockData;
+            cauldron.setLevel(3);
+        });
+        BlockData powderSnowCauldron = Bukkit.createBlockData(Material.POWDER_SNOW_CAULDRON, blockData -> {
+            Levelled cauldron = (Levelled) blockData;
+            cauldron.setLevel(3);
+        });
+        ItemStack waterBucket = new ItemStack(Material.WATER_BUCKET);
+        ItemStack lavaBucket = new ItemStack(Material.LAVA_BUCKET);
+        ItemStack powderSnowBucket = new ItemStack(Material.POWDER_SNOW_BUCKET);
+        Location dispenserLocation = blockDispenser.getLocation();
+        Location cauldronLocation = block.getLocation();
+        Sound lavaDispense = Sound.ITEM_BUCKET_EMPTY_LAVA;
+        Sound lavaEmpty = Sound.ITEM_BUCKET_FILL_LAVA;
+        Sound waterDispense = Sound.ITEM_BUCKET_EMPTY;
+        Sound waterEmpty = Sound.ITEM_BUCKET_FILL;
+        Sound powderSnowDispense = Sound.ITEM_BUCKET_EMPTY_POWDER_SNOW;
+        Sound powderSnowEmpty = Sound.ITEM_BUCKET_FILL_POWDER_SNOW;
+        Material dispensedItemMaterial = event.getItemStack().getType();
+        ItemStack dispensedItem = event.getItemStack();
+        Material material = block.getType();
+
+        if(!(cauldronTypes.contains(block.getType()))) return;
+        if(!(bucketTypes.contains(dispensedItemMaterial))) return;
+        switch (material){
+            case CAULDRON:
+                if(dispensedItemMaterial.equals(Material.BUCKET)){
+                    return;
+                } else {
+                    switch (dispensedItemMaterial) {
+                        case LAVA_BUCKET -> {
+                            block.setType(Material.LAVA_CAULDRON);
+                            dispensedItem.setType(Material.BUCKET);
+                            playSounds(dispenserLocation, lavaDispense);
+                            event.setCancelled(true);
+                            return;
+                        }
+                        case WATER_BUCKET -> {
+                            block.setBlockData(waterCauldron);
+                            dispensedItem.setType(Material.BUCKET);
+                            playSounds(dispenserLocation, waterDispense);
+                            event.setCancelled(true);
+                            return;
+                        }
+                        case POWDER_SNOW_BUCKET -> {
+                            block.setBlockData(powderSnowCauldron);
+                            dispensedItem.setType(Material.BUCKET);
+                            playSounds(dispenserLocation, powderSnowDispense);
+                            event.setCancelled(true);
+                            return;
+                        }
+                    }
+                }
+
+            case LAVA_CAULDRON:
+                if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
+                block.setType(Material.CAULDRON);
+                if(dispensedItem.getAmount() > 1) {
+                    dispensedItem.setAmount(dispensedItem.getAmount() - 1);
+                    if (emptySlot == -1) {
+                        block.getWorld().dropItem(cauldronLocation, lavaBucket);
+                        playSounds(dispenserLocation, lavaEmpty);
+                        event.setCancelled(true);
+                        return;
+                    }
+                    event.setCancelled(true);
+                    playSounds(dispenserLocation, lavaEmpty);
+                    blockDispenser.getInventory().setItem(emptySlot, lavaBucket);
+                    return;
+                }
+                event.setCancelled(true);
+                playSounds(dispenserLocation, lavaEmpty);
+                dispensedItem.setType(Material.LAVA_BUCKET);
+                return;
+            case WATER_CAULDRON:
+                if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
+                cauldronBlock = (Levelled) block.getBlockData();
+                if(cauldronBlock.getLevel() < 3) {
+                    event.setCancelled(true);
+                    return;
+                }
+                block.setType(Material.CAULDRON);
+                if(dispensedItem.getAmount() > 1){
+                    dispensedItem.setAmount(dispensedItem.getAmount() - 1);
+                    if(emptySlot == -1){
+                        block.getWorld().dropItem(cauldronLocation, waterBucket);
+                        playSounds(dispenserLocation, waterEmpty);
+                        event.setCancelled(true);
+                        return;
+                    }
+                    event.setCancelled(true);
+                    playSounds(dispenserLocation, waterEmpty);
+                    blockDispenser.getInventory().setItem(emptySlot, waterBucket);
+                    return;
+                }
+                event.setCancelled(true);
+                playSounds(dispenserLocation, waterEmpty);
+                dispensedItem.setType(Material.WATER_BUCKET);
+                return;
+            case POWDER_SNOW_CAULDRON:
+                if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
+                cauldronBlock = (Levelled) block.getBlockData();
+                if(cauldronBlock.getLevel() < 3) {
+                    event.setCancelled(true);
+                    return;
+                }
+                block.setType(Material.CAULDRON);
+                if(dispensedItem.getAmount() > 1){
+                    dispensedItem.setAmount(dispensedItem.getAmount() - 1);
+                    if(emptySlot == -1){
+                        block.getWorld().dropItem(cauldronLocation, powderSnowBucket);
+                        playSounds(dispenserLocation, powderSnowEmpty);
+                        event.setCancelled(true);
+                        return;
+                    }
+                    event.setCancelled(true);
+                    playSounds(dispenserLocation, powderSnowEmpty);
+                    blockDispenser.getInventory().setItem(emptySlot, powderSnowBucket);
+                    return;
+                }
+                event.setCancelled(true);
+                playSounds(dispenserLocation, powderSnowEmpty);
+                dispensedItem.setType(Material.POWDER_SNOW_BUCKET);
+        }
+    }
+    public void playSounds(Location dLoc, Sound actionSound){
+        dLoc.getWorld().playSound(dLoc, dispenseSound, blockSound, 1, 1);
+        dLoc.getWorld().playSound(dLoc, actionSound, blockSound, 1, 1);
+    }
+}
+

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/DispenserCauldronListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/DispenserCauldronListener.java
@@ -38,9 +38,6 @@ public class DispenserCauldronListener implements Listener {
             Levelled cauldron = (Levelled) blockData;
             cauldron.setLevel(3);
         });
-        ItemStack waterBucket = new ItemStack(Material.WATER_BUCKET);
-        ItemStack lavaBucket = new ItemStack(Material.LAVA_BUCKET);
-        ItemStack powderSnowBucket = new ItemStack(Material.POWDER_SNOW_BUCKET);
         Location dispenserLocation = blockDispenser.getLocation();
         Location cauldronLocation = block.getLocation();
         Sound lavaDispense = Sound.ITEM_BUCKET_EMPTY_LAVA;
@@ -89,6 +86,7 @@ public class DispenserCauldronListener implements Listener {
                 if(!(dispensedItemMaterial.equals(Material.BUCKET))) return;
                 block.setType(Material.CAULDRON);
                 if(dispensedItem.getAmount() > 1) {
+                    ItemStack lavaBucket = new ItemStack(Material.LAVA_BUCKET);
                     dispensedItem.setAmount(dispensedItem.getAmount() - 1);
                     if (emptySlot == -1) {
                         block.getWorld().dropItem(cauldronLocation, lavaBucket);
@@ -114,6 +112,7 @@ public class DispenserCauldronListener implements Listener {
                 }
                 block.setType(Material.CAULDRON);
                 if(dispensedItem.getAmount() > 1){
+                    ItemStack waterBucket = new ItemStack(Material.WATER_BUCKET);
                     dispensedItem.setAmount(dispensedItem.getAmount() - 1);
                     if(emptySlot == -1){
                         block.getWorld().dropItem(cauldronLocation, waterBucket);
@@ -139,6 +138,7 @@ public class DispenserCauldronListener implements Listener {
                 }
                 block.setType(Material.CAULDRON);
                 if(dispensedItem.getAmount() > 1){
+                    ItemStack powderSnowBucket = new ItemStack(Material.POWDER_SNOW_BUCKET);
                     dispensedItem.setAmount(dispensedItem.getAmount() - 1);
                     if(emptySlot == -1){
                         block.getWorld().dropItem(cauldronLocation, powderSnowBucket);

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/FarmingListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/FarmingListener.java
@@ -1,0 +1,54 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import me.youhavetrouble.purpurextras.PurpurExtras;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.type.Cocoa;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FarmingListener implements Listener {
+
+    List<Material> farmables = Arrays.asList(Material.CARROTS, Material.COCOA, Material.NETHER_WART, Material.POTATOES, Material.WHEAT, Material.BEETROOTS);
+
+    @EventHandler
+    public void rightClickFarmables(PlayerInteractEvent event) {
+        if (event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        if(!(event.getAction().isRightClick())) return;
+        if (event.getClickedBlock() == null) return;
+        if (!(farmables.contains(event.getClickedBlock().getType()))) return;
+        Player player = event.getPlayer();
+        Block clickedSpot = event.getClickedBlock();
+        Material clickedMaterial = clickedSpot.getType();
+        Ageable clickedCrop = (Ageable) clickedSpot.getBlockData();
+        ItemStack itemUsed = player.getInventory().getItemInMainHand();
+        BlockFace facing = null;
+        if (clickedCrop.getMaximumAge() != clickedCrop.getAge()) return;
+        if (clickedMaterial.equals(Material.COCOA)){
+            Cocoa clickedCocoa = (Cocoa) event.getClickedBlock().getBlockData();
+            facing = clickedCocoa.getFacing();
+            Cocoa cocoaData = (Cocoa) Bukkit.createBlockData(Material.COCOA);
+            event.setCancelled(true);
+            event.getClickedBlock().breakNaturally(itemUsed);
+            cocoaData.setFacing(facing);
+            clickedSpot.setBlockData(cocoaData);
+            return;
+        }
+        event.setCancelled(true);
+        event.getClickedBlock().breakNaturally(itemUsed);
+        event.getClickedBlock().setType(clickedMaterial);
+    }
+}

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
@@ -1,0 +1,26 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
+import org.bukkit.Material;
+import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+
+public class ItemFrameListener implements Listener {
+
+    @EventHandler
+    public void onItemFrameInteract(PlayerInteractEntityEvent event){
+        Player player = event.getPlayer();
+        Entity entity = event.getRightClicked();
+        if(event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        if(!player.isSneaking()) return;
+        if(entity instanceof ItemFrame itemFrame){
+            if (itemFrame.getItem().getType().equals(Material.AIR)) return;
+        event.setCancelled(true);
+        itemFrame.setVisible(!itemFrame.isVisible());
+        itemFrame.setFixed(!itemFrame.isFixed());
+        }
+    }
+}

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/NetherRoofBuildListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/NetherRoofBuildListener.java
@@ -1,0 +1,17 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class NetherRoofBuildListener implements Listener {
+
+    @EventHandler
+    public void onBuild(BlockPlaceEvent event){
+        Block block = event.getBlock();
+        if(!(block.getWorld().hasCeiling())) return;
+        if(block.getLocation().getBlockY() < 128) return;
+        event.setCancelled(true);
+    }
+}

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
@@ -1,0 +1,23 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class SpawnerPlacementListener implements Listener {
+
+    @EventHandler
+    public void onSpawnerPlace(BlockPlaceEvent event){
+        Material block = event.getBlock().getType();
+        Player player = event.getPlayer();
+        if (!(block.equals(Material.SPAWNER))) return;
+        if (!(player.hasPermission("purpurextras.spawnerPlace"))){
+            player.sendMessage(Component.text("You do not have permission to place spawners", NamedTextColor.RED));
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
Right click to harvest
https://github.com/PurpurMC/Purpur/discussions/604
Simple right-click to harvest, auto-replant, uses tool in hand so will apply fortune if holding fortune tool in your main hand.
Valid farmables are Carrots, Potatoes, Wheat, Beetroots, Nether wart, and Cocoa

Nether Roof
https://github.com/PurpurMC/Purpur/discussions/518
Prevents building above nether roof in normally-generated nether worlds (no adjusted ceiling height)

Spawners
https://github.com/PurpurMC/Purpur/issues/542
Adds a permission to allow placement, prevents placement at all if enabled and the player doesn't have the permission (Normal purpur behavior allows placement, but places as a pig spawner)

Dispensers
https://github.com/PurpurMC/Purpur/discussions/585
Allows dispensers to dispense/remove lava, water, and powdered snow into/from cauldrons

Invis Item Frames
(no link for this I just wanted it)
Shift-right-click an item frame to turn it invisible. The frame must have something in it. It will also turn the frame fixed, so if you wanna rotate/remove the item, you'll have to shift-right-click again to turn it visible, then do it.

(the code likely needs a lot of cleaning up)