### PR TITLE
Permission for placing spawners

### DIFF
--- a/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
@@ -50,6 +50,8 @@ public class PurpurConfig {
 
         enableFeature(RespawnAnchorNeedsChargeListener.class, !getBoolean("settings.gameplay-settings.respawn-anchor-needs-charges", true));
 
+        enableFeature(SpawnerPlacementListener.class, getBoolean("settings.blocks.use-spawner-placement-permission", false));
+
         enableFeature(EscapeCommandSlashListener.class, getBoolean("settings.chat.escape-commands", false));
 
         getAnvilCrushIndex();

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
@@ -5,12 +5,13 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 
 public class SpawnerPlacementListener implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSpawnerPlace(BlockPlaceEvent event){
         Material block = event.getBlock().getType();
         Player player = event.getPlayer();

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
@@ -1,0 +1,23 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class SpawnerPlacementListener implements Listener {
+
+    @EventHandler
+    public void onSpawnerPlace(BlockPlaceEvent event){
+        Material block = event.getBlock().getType();
+        Player player = event.getPlayer();
+        if (!(block.equals(Material.SPAWNER))) return;
+        if (!(player.hasPermission("purpurextras.spawnerPlace"))){
+            player.sendMessage(Component.text("You do not have permission to place spawners", NamedTextColor.RED));
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/SpawnerPlacementListener.java
@@ -3,22 +3,29 @@ package me.youhavetrouble.purpurextras.listeners;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
+import org.bukkit.block.CreatureSpawner;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 
+import java.util.Locale;
+
 public class SpawnerPlacementListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSpawnerPlace(BlockPlaceEvent event){
-        Material block = event.getBlock().getType();
         Player player = event.getPlayer();
-        if (!(block.equals(Material.SPAWNER))) return;
-        if (!(player.hasPermission("purpurextras.spawnerPlace"))){
-            player.sendMessage(Component.text("You do not have permission to place spawners", NamedTextColor.RED));
+        String entityType;
+        if (event.getBlock().getState(false) instanceof CreatureSpawner spawner) {
+            entityType = ("." + spawner.getSpawnedType()).toLowerCase(Locale.ROOT);
+        } else {
+            return;
+        }
+        if (!(player.hasPermission("purpurextras.spawnerplace" + entityType) || player.hasPermission("purpurextras.spawnerplace.everything"))){
             event.setCancelled(true);
+            player.sendMessage(Component.text("You do not have permission to place a " + spawner.getSpawnedType().toString().toLowerCase(Locale.ROOT) + " spawner!", NamedTextColor.RED));
         }
     }
 }


### PR DESCRIPTION
Adds a permission to allow placement, prevents placement at all if enabled and the player doesn't have the permission (Normal purpur behavior allows placement, but places as a pig spawner)
https://github.com/PurpurMC/Purpur/issues/542