### PR TITLE
Shift-right-click for invisible item frames

### DIFF
--- a/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/config/PurpurConfig.java
@@ -48,6 +48,8 @@ public class PurpurConfig {
 
         enableFeature(ChorusFlowerListener.class, getBoolean("settings.blocks.chorus-flowers-always-drop", false));
 
+        enableFeature(ItemFrameListener.class, getBoolean("settings.blocks.shift-right-click-for-invisible-item-frames", false));
+
         enableFeature(RespawnAnchorNeedsChargeListener.class, !getBoolean("settings.gameplay-settings.respawn-anchor-needs-charges", true));
 
         enableFeature(EscapeCommandSlashListener.class, getBoolean("settings.chat.escape-commands", false));

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
@@ -1,0 +1,26 @@
+package me.youhavetrouble.purpurextras.listeners;
+
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
+import org.bukkit.Material;
+import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+
+public class ItemFrameListener implements Listener {
+
+    @EventHandler
+    public void onItemFrameInteract(PlayerInteractEntityEvent event){
+        Player player = event.getPlayer();
+        Entity entity = event.getRightClicked();
+        if(event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        if(!player.isSneaking()) return;
+        if(entity instanceof ItemFrame itemFrame){
+            if (itemFrame.getItem().getType().equals(Material.AIR)) return;
+        event.setCancelled(true);
+        itemFrame.setVisible(!itemFrame.isVisible());
+        itemFrame.setFixed(!itemFrame.isFixed());
+        }
+    }
+}

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
@@ -17,11 +17,10 @@ public class ItemFrameListener implements Listener {
         Entity entity = event.getRightClicked();
         if(event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
         if(!player.isSneaking()) return;
-        if(entity instanceof ItemFrame itemFrame){
-            if (itemFrame.getItem().getType().equals(Material.AIR)) return;
+        if(!(entity instanceof ItemFrame itemFrame)) return;
+        if(itemFrame.getItem().getType().equals(Material.AIR)) return;
         event.setCancelled(true);
         itemFrame.setVisible(!itemFrame.isVisible());
         itemFrame.setFixed(!itemFrame.isFixed());
-        }
     }
 }

--- a/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
+++ b/src/main/java/me/youhavetrouble/purpurextras/listeners/ItemFrameListener.java
@@ -4,13 +4,14 @@ import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import org.bukkit.Material;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 public class ItemFrameListener implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onItemFrameInteract(PlayerInteractEntityEvent event){
         Player player = event.getPlayer();
         Entity entity = event.getRightClicked();


### PR DESCRIPTION
Shift-right-click an item frame to turn it invisible. The frame must have something in it. It will also turn the frame fixed, so if you wanna rotate/remove the item, you'll have to shift-right-click again to turn it visible, then do it.