### PR TITLE
prevent building on nether roof

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/PurpurConfig.java
+++ b/src/main/java/org/purpurmc/purpurextras/PurpurConfig.java
@@ -51,6 +51,13 @@ public class PurpurConfig {
         return def;
     }
 
+    public int getInt(String path, int def) {
+        if (config.isSet(path))
+            return config.getInt(path, def);
+        config.set(path, def);
+        return def;
+    }
+
     /**
      * @param defKV Default key-value map
      */

--- a/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
@@ -1,0 +1,57 @@
+package org.purpurmc.purpurextras.modules;
+
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.permissions.PermissionDefault;
+import org.purpurmc.purpurextras.PurpurConfig;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+import static org.bukkit.util.permissions.DefaultPermissions.registerPermission;
+
+public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
+
+    private final int configBuildHeight;
+    private final String noPermissionMessageContent;
+    private final boolean noPermissionMessage;
+
+    protected NetherBuildHeightModule() {
+        PurpurConfig config = PurpurExtras.getPurpurConfig();
+        this.configBuildHeight = config.getInt("settings.block-building-above-nether.height-limit", 128);
+        this.noPermissionMessage = config.getBoolean("settings.block-building-above-nether.no-permission-message.enabled", false);
+        this.noPermissionMessageContent = config.getString("settings.block-building-above-nether.no-permission-message.message", "<red>Max build height in this world is: <gold><height>");
+    }
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        registerPermission("purpurextras.netherbypass", "Allows player to bypass the configured max nether build height", PermissionDefault.OP);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.block-building-above-nether.enabled", false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onNetherRoofBuild(BlockPlaceEvent event){
+        Block block = event.getBlock();
+        Player player = event.getPlayer();
+        if(!(block.getWorld().getEnvironment().equals(World.Environment.NETHER))) return;
+        if(block.getLocation().getBlockY() < configBuildHeight) return;
+        if(player.hasPermission("purpurextras.netherbypass")) return;
+        if(noPermissionMessage){
+            player.sendActionBar(MiniMessage.miniMessage().deserialize(noPermissionMessageContent, Placeholder.unparsed("height", String.valueOf(configBuildHeight))));
+        }
+        event.setCancelled(true);
+
+    }
+
+}

--- a/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
@@ -20,6 +20,7 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
     private final int configBuildHeight;
     private final String noPermissionMessageContent;
     private final boolean noPermissionMessage;
+    private final String netherBuildHeightBypassPermission = "purpurextras.netherbuildheightbypass";
 
     protected NetherBuildHeightModule() {
         PurpurConfig config = PurpurExtras.getPurpurConfig();
@@ -32,7 +33,7 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        registerPermission("purpurextras.netherbypass", "Allows player to bypass the configured max nether build height", PermissionDefault.OP);
+        registerPermission(netherBuildHeightBypassPermission, "Allows player to bypass the configured max nether build height", PermissionDefault.OP);
     }
 
     @Override
@@ -46,7 +47,7 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
         Player player = event.getPlayer();
         if(!(block.getWorld().getEnvironment().equals(World.Environment.NETHER))) return;
         if(block.getLocation().getBlockY() < configBuildHeight) return;
-        if(player.hasPermission("purpurextras.netherbypass")) return;
+        if(player.hasPermission(netherBuildHeightBypassPermission)) return;
         if(noPermissionMessage){
             player.sendActionBar(MiniMessage.miniMessage().deserialize(noPermissionMessageContent, Placeholder.unparsed("height", String.valueOf(configBuildHeight))));
         }

--- a/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
@@ -1,6 +1,5 @@
 package org.purpurmc.purpurextras.modules;
 
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -33,11 +32,11 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        registerPermission(netherBuildHeightBypassPermission, "Allows player to bypass the configured max nether build height", PermissionDefault.OP);
     }
 
     @Override
     public boolean shouldEnable() {
+        registerPermission(netherBuildHeightBypassPermission, "Allows player to bypass the configured max nether build height", PermissionDefault.OP);
         return PurpurExtras.getPurpurConfig().getBoolean("settings.block-building-above-nether.enabled", false);
     }
 
@@ -45,14 +44,13 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
     public void onNetherRoofBuild(BlockPlaceEvent event){
         Block block = event.getBlock();
         Player player = event.getPlayer();
-        if(!(block.getWorld().getEnvironment().equals(World.Environment.NETHER))) return;
-        if(block.getLocation().getBlockY() < configBuildHeight) return;
-        if(player.hasPermission(netherBuildHeightBypassPermission)) return;
-        if(noPermissionMessage){
-            player.sendActionBar(MiniMessage.miniMessage().deserialize(noPermissionMessageContent, Placeholder.unparsed("height", String.valueOf(configBuildHeight))));
+        if (!(block.getWorld().getEnvironment().equals(World.Environment.NETHER))) return;
+        if (block.getLocation().getBlockY() < configBuildHeight) return;
+        if (player.hasPermission(netherBuildHeightBypassPermission)) return;
+        if (noPermissionMessage) {
+            player.sendActionBar(PurpurExtras.getInstance().miniMessage.deserialize(noPermissionMessageContent, Placeholder.unparsed("height", String.valueOf(configBuildHeight))));
         }
         event.setCancelled(true);
-
     }
 
 }

--- a/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/NetherBuildHeightModule.java
@@ -18,14 +18,12 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
 
     private final int configBuildHeight;
     private final String noPermissionMessageContent;
-    private final boolean noPermissionMessage;
     private final String netherBuildHeightBypassPermission = "purpurextras.netherbuildheightbypass";
 
     protected NetherBuildHeightModule() {
         PurpurConfig config = PurpurExtras.getPurpurConfig();
         this.configBuildHeight = config.getInt("settings.block-building-above-nether.height-limit", 128);
-        this.noPermissionMessage = config.getBoolean("settings.block-building-above-nether.no-permission-message.enabled", false);
-        this.noPermissionMessageContent = config.getString("settings.block-building-above-nether.no-permission-message.message", "<red>Max build height in this world is: <gold><height>");
+        this.noPermissionMessageContent = config.getString("settings.block-building-above-nether.no-permission-message", "<red>Max build height in this world is: <gold><height>");
     }
 
     @Override
@@ -47,7 +45,7 @@ public class NetherBuildHeightModule implements PurpurExtrasModule, Listener {
         if (!(block.getWorld().getEnvironment().equals(World.Environment.NETHER))) return;
         if (block.getLocation().getBlockY() < configBuildHeight) return;
         if (player.hasPermission(netherBuildHeightBypassPermission)) return;
-        if (noPermissionMessage) {
+        if (!"".equals(noPermissionMessageContent)) {
             player.sendActionBar(PurpurExtras.getInstance().miniMessage.deserialize(noPermissionMessageContent, Placeholder.unparsed("height", String.valueOf(configBuildHeight))));
         }
         event.setCancelled(true);

--- a/src/main/java/org/purpurmc/purpurextras/modules/PurpurExtrasModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/PurpurExtrasModule.java
@@ -37,7 +37,7 @@ public interface PurpurExtrasModule {
         modules.add(new OpenIronDoorsWithHandModule());
         modules.add(new LightningTransformsMobsModule());
         modules.add(new GrindstoneEnchantsBooksModule());
-
+        modules.add(new NetherBuildHeightModule());
         modules.add(new UpgradeWoodToStoneToolsModule());
         modules.add(new UpgradeStoneToIronToolsModule());
         modules.add(new UpgradeIronToDiamondsToolsModule());


### PR DESCRIPTION
Prevent building on nether roof with configurable height. "purpurextras.netherbypass" allows this to be bypassed. Actionbar 'max build height' message can also be configured