### PR TITLE
Invisible Item Frames

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
@@ -1,0 +1,46 @@
+package org.purpurmc.purpurextras.modules;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.permissions.PermissionDefault;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+import static org.bukkit.util.permissions.DefaultPermissions.registerPermission;
+
+public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
+
+    protected InvisibleItemFrameModule() {}
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        registerPermission("purpurextras.invisibleframes", "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.blocks.shift-right-click-for-invisible-item-frames", false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onItemFrameInteract(PlayerInteractEntityEvent event){
+        Player player = event.getPlayer();
+        Entity entity = event.getRightClicked();
+        if(event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        if(!player.isSneaking()) return;
+        if(!(entity instanceof ItemFrame itemFrame)) return;
+        if(itemFrame.getItem().getType().equals(Material.AIR)) return;
+        if(!player.hasPermission("purpurextras.invisibleframes")) return;
+        event.setCancelled(true);
+        itemFrame.setVisible(!itemFrame.isVisible());
+        itemFrame.setFixed(!itemFrame.isFixed());
+    }
+}

--- a/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
@@ -24,11 +24,11 @@ public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        registerPermission(invisFramePermission, "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
     }
 
     @Override
     public boolean shouldEnable() {
+        registerPermission(invisFramePermission, "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
         return PurpurExtras.getPurpurConfig().getBoolean("settings.blocks.shift-right-click-for-invisible-item-frames", false);
     }
 

--- a/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
@@ -10,9 +10,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.util.permissions.DefaultPermissions;
 import org.purpurmc.purpurextras.PurpurExtras;
-
-import static org.bukkit.util.permissions.DefaultPermissions.registerPermission;
 
 public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
 
@@ -28,19 +27,22 @@ public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
 
     @Override
     public boolean shouldEnable() {
-        registerPermission(invisFramePermission, "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
+        DefaultPermissions.registerPermission(invisFramePermission, "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
         return PurpurExtras.getPurpurConfig().getBoolean("settings.blocks.shift-right-click-for-invisible-item-frames", false);
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onItemFrameInteract(PlayerInteractEntityEvent event){
+        if (event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+
         Player player = event.getPlayer();
+        if (!player.isSneaking()) return;
+
         Entity entity = event.getRightClicked();
-        if(event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
-        if(!player.isSneaking()) return;
-        if(!(entity instanceof ItemFrame itemFrame)) return;
-        if(itemFrame.getItem().getType().equals(Material.AIR)) return;
-        if(!player.hasPermission(invisFramePermission)) return;
+        if (!(entity instanceof ItemFrame itemFrame)) return;
+        if (itemFrame.getItem().getType().equals(Material.AIR)) return;
+        if (!player.hasPermission(invisFramePermission)) return;
+
         event.setCancelled(true);
         itemFrame.setVisible(!itemFrame.isVisible());
         itemFrame.setFixed(!itemFrame.isFixed());

--- a/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
@@ -40,7 +40,7 @@ public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
         if(!player.isSneaking()) return;
         if(!(entity instanceof ItemFrame itemFrame)) return;
         if(itemFrame.getItem().getType().equals(Material.AIR)) return;
-        if(!player.hasPermission("purpurextras.invisibleframes")) return;
+        if(!player.hasPermission(invisFramePermission)) return;
         event.setCancelled(true);
         itemFrame.setVisible(!itemFrame.isVisible());
         itemFrame.setFixed(!itemFrame.isFixed());

--- a/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
@@ -18,11 +18,13 @@ public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
 
     protected InvisibleItemFrameModule() {}
 
+    private final String invisFramePermission = "purpurextras.invisibleframes";
+
     @Override
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        registerPermission("purpurextras.invisibleframes", "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
+        registerPermission(invisFramePermission, "Allows player to shift-right-click an item frame to turn it invisible", PermissionDefault.OP);
     }
 
     @Override

--- a/src/main/java/org/purpurmc/purpurextras/modules/PurpurExtrasModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/PurpurExtrasModule.java
@@ -37,7 +37,7 @@ public interface PurpurExtrasModule {
         modules.add(new OpenIronDoorsWithHandModule());
         modules.add(new LightningTransformsMobsModule());
         modules.add(new GrindstoneEnchantsBooksModule());
-
+        modules.add(new InvisibleItemFrameModule());
         modules.add(new UpgradeWoodToStoneToolsModule());
         modules.add(new UpgradeStoneToIronToolsModule());
         modules.add(new UpgradeIronToDiamondsToolsModule());


### PR DESCRIPTION
Shift-right-click to turn item frames invisible. Sets frame to be fixed when turning it invisible, so the item cannot be removed/damaged/rotated while the frame is invisible.