### PR TITLE
Add feature based off Stop Drop N Roll mod

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
@@ -41,7 +41,7 @@ public class StopDropNRollModule implements PurpurExtrasModule, Listener {
         Player player = event.getPlayer();
         boolean isSneaking = event.isSneaking();
 
-        if (player.getFireTicks() > 0 && isSneaking && !playerLastSneakMap.get(player)) {
+        if (player.getFireTicks() > 0 && isSneaking && !playerLastSneakMap.get(player) && Math.random() < chance) {
             player.setFireTicks((int) (player.getFireTicks() * (1f - amount)));
         }
 

--- a/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public class StopDropNRollModule implements PurpurExtrasModule, Listener {
 
-    private final Map<Player, Boolean> playerLastSneakMap = new HashMap<>();;
+    private final Map<Player, Boolean> playerLastSneakMap = new HashMap<>();
     private double chance;
     private double amount;
 
@@ -36,7 +36,7 @@ public class StopDropNRollModule implements PurpurExtrasModule, Listener {
         return PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.chance", 0) != 0;
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerToggleSneak(PlayerToggleSneakEvent event){
         Player player = event.getPlayer();
         boolean isSneaking = event.isSneaking();

--- a/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
@@ -27,13 +27,13 @@ public class StopDropNRollModule implements PurpurExtrasModule, Listener {
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        chance = PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.chance", 0);
-        amount = PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.amount", 0.5);
+        chance = PurpurExtras.getPurpurConfig().getDouble("settings.twerk-to-reduce-burn-time.chance", 0);
+        amount = PurpurExtras.getPurpurConfig().getDouble("settings.twerk-to-reduce-burn-time.amount", 0.5);
     }
 
     @Override
     public boolean shouldEnable() {
-        return PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.chance", 0) != 0;
+        return PurpurExtras.getPurpurConfig().getDouble("settings.twerk-to-reduce-burn-time.chance", 0) != 0;
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
@@ -1,0 +1,60 @@
+package org.purpurmc.purpurextras.modules;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Allows the player to Stop Drop N Roll to get extinguished from any flames.
+ */
+public class StopDropNRollModule implements PurpurExtrasModule, Listener {
+
+    private final Map<Player, Boolean> playerLastSneakMap = new HashMap<>();;
+    private double chance;
+    private double amount;
+
+    protected StopDropNRollModule() {}
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        chance = PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.chance", 0);
+        amount = PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.amount", 0.5);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        return PurpurExtras.getPurpurConfig().getDouble("settings.stopdropandroll.chance", 0) != 0;
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerToggleSneak(PlayerToggleSneakEvent event){
+        Player player = event.getPlayer();
+        boolean isSneaking = event.isSneaking();
+
+        if (player.getFireTicks() > 0 && isSneaking && !playerLastSneakMap.get(player)) {
+            player.setFireTicks((int) (player.getFireTicks() * (1f - amount)));
+        }
+
+        playerLastSneakMap.put(player, isSneaking);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        playerLastSneakMap.put(event.getPlayer(), false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        playerLastSneakMap.remove(event.getPlayer());
+    }
+}


### PR DESCRIPTION
Adds the mod Stop Drop N Roll (https://legacy.curseforge.com/minecraft/mc-mods/stop-drop-n-roll) as a feature to this plugin.

Adds a module that has a chance to lower the remaining fire ticks by a percentage. It is disabled if the chance is set to 0.

I'm sure my code will require some changes