### PR TITLE
Add option to play a sound when a leash snaps

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
@@ -9,6 +9,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityUnleashEvent;
 import org.purpurmc.purpurextras.PurpurExtras;
 
+import java.util.Locale;
+
 /**
  * Adds a sound for when the leash snaps
  */
@@ -21,10 +23,11 @@ public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
     protected LeashSnapSoundModule() {
         String soundId = PurpurExtras.getPurpurConfig().getString("settings.leash-snap.sound", "block.bamboo.break");
 
-        for (org.bukkit.Sound bukkitSound : org.bukkit.Sound.values()) {
-            if (bukkitSound.key().value().equals(soundId)) {
-                sound = bukkitSound.key();
-            }
+        try {
+            sound = org.bukkit.Sound.valueOf(soundId.replace('.', '_').toUpperCase(Locale.ROOT)).key();
+        } catch (IllegalArgumentException e) {
+            System.out.println("Could not set sound to '" + soundId + "', using default value 'block.bamboo.break'");
+            sound = Key.key(Key.MINECRAFT_NAMESPACE, "block.bamboo.break");
         }
 
         volume = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.volume", 1f);

--- a/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
@@ -2,6 +2,7 @@ package org.purpurmc.purpurextras.modules;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
+import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -13,10 +14,19 @@ import org.purpurmc.purpurextras.PurpurExtras;
  */
 public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
 
+    private Key sound;
     private double volume;
     private double pitch;
 
     protected LeashSnapSoundModule() {
+        String soundId = PurpurExtras.getPurpurConfig().getString("settings.leash-snap.sound", "block.bamboo.break");
+
+        for (org.bukkit.Sound bukkitSound : org.bukkit.Sound.values()) {
+            if (bukkitSound.key().value().equals(soundId)) {
+                sound = bukkitSound.key();
+            }
+        }
+
         volume = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.volume", 1f);
         pitch = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.pitch", 1.25f);
     }
@@ -29,7 +39,7 @@ public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
 
     @Override
     public boolean shouldEnable() {
-        return PurpurExtras.getPurpurConfig().getBoolean("settings.leash-snap.enabled", false);
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.leash-snap.enabled", false) && sound != null;
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -37,6 +47,6 @@ public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
 
         if (event.getReason() != EntityUnleashEvent.UnleashReason.DISTANCE) return;
 
-        event.getEntity().getWorld().playSound(Sound.sound(org.bukkit.Sound.BLOCK_BAMBOO_BREAK.key(), Sound.Source.PLAYER, (float) volume, (float) pitch), event.getEntity());
+        event.getEntity().getWorld().playSound(Sound.sound(sound, Sound.Source.PLAYER, (float) volume, (float) pitch), event.getEntity());
     }
 }

--- a/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
@@ -26,7 +26,7 @@ public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
         try {
             sound = org.bukkit.Sound.valueOf(soundId.replace('.', '_').toUpperCase(Locale.ROOT)).key();
         } catch (IllegalArgumentException e) {
-            System.out.println("Could not set sound to '" + soundId + "', using default value 'block.bamboo.break'");
+            PurpurExtras.getInstance().getLogger().warning("Could not set sound to '" + soundId + "', using default value 'block.bamboo.break'");
             sound = Key.key(Key.MINECRAFT_NAMESPACE, "block.bamboo.break");
         }
 

--- a/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
@@ -1,0 +1,42 @@
+package org.purpurmc.purpurextras.modules;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityUnleashEvent;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+/**
+ * Adds a sound for when the leash snaps
+ */
+public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
+
+    private double volume;
+    private double pitch;
+
+    protected LeashSnapSoundModule() {
+        volume = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.volume", 1f);
+        pitch = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.pitch", 1.25f);
+    }
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.leash-snap.enabled", false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onLeashBreak(EntityUnleashEvent event){
+
+        if (event.getReason() != EntityUnleashEvent.UnleashReason.DISTANCE) return;
+
+        event.getEntity().getWorld().playSound(Sound.sound(org.bukkit.Sound.BLOCK_BAMBOO_BREAK.key(), Sound.Source.PLAYER, (float) volume, (float) pitch), event.getEntity());
+    }
+}

--- a/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/LeashSnapSoundModule.java
@@ -3,6 +3,7 @@ package org.purpurmc.purpurextras.modules;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import org.bukkit.NamespacedKey;
+import org.bukkit.SoundCategory;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -16,20 +17,12 @@ import java.util.Locale;
  */
 public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
 
-    private Key sound;
+    private String sound;
     private double volume;
     private double pitch;
 
     protected LeashSnapSoundModule() {
-        String soundId = PurpurExtras.getPurpurConfig().getString("settings.leash-snap.sound", "block.bamboo.break");
-
-        try {
-            sound = org.bukkit.Sound.valueOf(soundId.replace('.', '_').toUpperCase(Locale.ROOT)).key();
-        } catch (IllegalArgumentException e) {
-            PurpurExtras.getInstance().getLogger().warning("Could not set sound to '" + soundId + "', using default value 'block.bamboo.break'");
-            sound = Key.key(Key.MINECRAFT_NAMESPACE, "block.bamboo.break");
-        }
-
+        sound = PurpurExtras.getPurpurConfig().getString("settings.leash-snap.sound", "minecraft:block.bamboo.break");
         volume = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.volume", 1f);
         pitch = PurpurExtras.getPurpurConfig().getDouble("settings.leash-snap.pitch", 1.25f);
     }
@@ -50,6 +43,6 @@ public class LeashSnapSoundModule implements PurpurExtrasModule, Listener {
 
         if (event.getReason() != EntityUnleashEvent.UnleashReason.DISTANCE) return;
 
-        event.getEntity().getWorld().playSound(Sound.sound(sound, Sound.Source.PLAYER, (float) volume, (float) pitch), event.getEntity());
+        event.getEntity().getWorld().playSound(event.getEntity().getLocation(), sound, SoundCategory.PLAYERS, (float) volume, (float) pitch);
     }
 }


### PR DESCRIPTION
Adds an option to play a sound when a leash snaps because of distance while leading mobs. It plays a pitched Bamboo Break sound currently. Pitch and Volume options are also config options.