### PR TITLE
Relocate config option code to class constructor instead of enable method

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/StopDropNRollModule.java
@@ -21,19 +21,20 @@ public class StopDropNRollModule implements PurpurExtrasModule, Listener {
     private double chance;
     private double amount;
 
-    protected StopDropNRollModule() {}
-
-    @Override
-    public void enable() {
-        PurpurExtras plugin = PurpurExtras.getInstance();
-        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    protected StopDropNRollModule() {
         chance = PurpurExtras.getPurpurConfig().getDouble("settings.twerk-to-reduce-burn-time.chance", 0);
         amount = PurpurExtras.getPurpurConfig().getDouble("settings.twerk-to-reduce-burn-time.amount", 0.5);
     }
 
     @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
     public boolean shouldEnable() {
-        return PurpurExtras.getPurpurConfig().getDouble("settings.twerk-to-reduce-burn-time.chance", 0) != 0;
+        return chance != 0;
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)


### PR DESCRIPTION
I made an oopsie when making my Stop Drop N Roll (twerk to reduce burn time) PR and had the config options in the `enable` method which stopped the `amount` option from generating unless it was enabled first. Just realised when installing the plugin on a server and it annoyed me.