### PR TITLE
Update manifest to stop remapping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,10 @@ tasks {
         archiveFileName.set("PurpurExtras-${version}.jar")
         relocate("org.reflections", "org.purpurmc.purpurextras.reflections")
         relocate("me.youhavetrouble.entiddy", "org.purpurmc.purpurextras.entiddy")
+
+        manifest {
+            attributes["paperweight-mappings-namespace"] = "mojang"
+        }
     }
 
     register("downloadServer") {


### PR DESCRIPTION
Indicated the plugin is Mojang Mapped, stopping live remapping by paper.
https://docs.papermc.io/paper/dev/project-setup#mojang-mappings
PurpurExtras does not use NMS, so this has no other effects.