### PR TITLE
Add item exclusion list to suspicious blocks

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/PurpurConfig.java
+++ b/src/main/java/org/purpurmc/purpurextras/PurpurConfig.java
@@ -30,6 +30,15 @@ public class PurpurConfig {
         }
     }
 
+    public boolean getBooleanIfExists(String path, boolean def) {
+        if (config.isSet(path)) {
+            Boolean setting = config.getBoolean(path, def);
+            config.set(path, null);
+            return setting;
+        }
+        return def;
+    }
+
     public boolean getBoolean(String path, boolean def) {
         if (config.isSet(path))
             return config.getBoolean(path, def);

--- a/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.purpurmc.purpurextras.PurpurExtras;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.purpurmc.purpurextras.util.MessageType;
 import java.util.List;
 
 /**
@@ -29,6 +30,7 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
     private boolean exclusionListStatus;
     private List<String> exclusionList;
     private String exclusionMessage;
+    private MessageType messageType;
 
     @Override
     public void enable() {
@@ -42,6 +44,11 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
         this.exclusionListStatus = PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enable-item-exclusion-list", false);
         this.exclusionList = PurpurExtras.getPurpurConfig().getList("settings.suspicious-blocks.item-exclusion-list", List.of("SHULKER_BOX"));
         this.exclusionMessage = PurpurExtras.getPurpurConfig().getString("settings.suspicious-blocks.item-excluded-message", "<red>The item you're using is on the excluded list!");
+        try {
+            this.messageType = MessageType.valueOf(PurpurExtras.getPurpurConfig().getString("settings.suspicious-blocks.message-type", "CHAT").toUpperCase());
+        } catch (IllegalArgumentException e) {
+            this.messageType = MessageType.CHAT;
+        }
         return susBlocksEnabled;
     }
 
@@ -57,7 +64,10 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
         if (itemStack == null) return;
         if (this.exclusionListStatus && this.exclusionList.contains(itemStack.getType().name())) {
             if (this.exclusionMessage.isEmpty()) return;
-            player.sendMessage(MiniMessage.miniMessage().deserialize(this.exclusionMessage));
+            switch (this.messageType) {
+                case CHAT -> player.sendMessage(MiniMessage.miniMessage().deserialize(this.exclusionMessage));
+                case ACTION_BAR -> player.sendActionBar(MiniMessage.miniMessage().deserialize(this.exclusionMessage));
+            }
             return;
         }
 

--- a/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
@@ -40,16 +40,15 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
 
     @Override
     public boolean shouldEnable() {
-        boolean susBlocksEnabled = PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enabled", PurpurExtras.getPurpurConfig().getBooleanIfExists("settings.create-suspicious-blocks", false));
-        this.exclusionListStatus = PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enable-item-exclusion-list", false);
-        this.exclusionList = PurpurExtras.getPurpurConfig().getList("settings.suspicious-blocks.item-exclusion-list", List.of("SHULKER_BOX"));
-        this.exclusionMessage = PurpurExtras.getPurpurConfig().getString("settings.suspicious-blocks.item-excluded-message", "<red>The item you're using is on the excluded list!");
+        this.exclusionListStatus = PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.exclusion-list.enable-item-exclusion-list", false);
+        this.exclusionList = PurpurExtras.getPurpurConfig().getList("settings.suspicious-blocks.exclusion-list.item-exclusion-list", List.of("SHULKER_BOX"));
+        this.exclusionMessage = PurpurExtras.getPurpurConfig().getString("settings.suspicious-blocks.exclusion-list.item-excluded-message", "<red>The item you're using is on the excluded list!");
         try {
-            this.messageType = MessageType.valueOf(PurpurExtras.getPurpurConfig().getString("settings.suspicious-blocks.message-type", "CHAT").toUpperCase());
+            this.messageType = MessageType.valueOf(PurpurExtras.getPurpurConfig().getString("settings.suspicious-blocks.exclusion-list.message-type", "CHAT").toUpperCase());
         } catch (IllegalArgumentException e) {
             this.messageType = MessageType.CHAT;
         }
-        return susBlocksEnabled;
+            return PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enabled", PurpurExtras.getPurpurConfig().getBooleanIfExists("settings.create-suspicious-blocks", false));
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
@@ -46,10 +46,9 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
         if (!player.isSneaking()) return;
         Block block = event.getClickedBlock();
         if (block == null) return;
-        if (exclusionListStatus && exclusionList.contains(event.getItem().getType().name())) return;
         if (block.getType() != Material.SAND && block.getType() != Material.GRAVEL) return;
         ItemStack itemStack = event.getItem();
-        if (itemStack == null) return;
+        if (itemStack == null || exclusionListStatus && exclusionList.contains(itemStack.getType().name())) return;
 
         switch (block.getType()) {
             case SAND -> block.setType(Material.SUSPICIOUS_SAND);

--- a/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
@@ -14,6 +14,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.purpurmc.purpurextras.PurpurExtras;
+import java.util.List;
 
 /**
  * If enabled, players will be able to shift-right click on sand and gravel with items in their hands to create
@@ -32,16 +33,20 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
 
     @Override
     public boolean shouldEnable() {
-        return PurpurExtras.getPurpurConfig().getBoolean("settings.create-suspicious-blocks", false);
+        Boolean susBlocksEnabled = PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enabled", PurpurExtras.getPurpurConfig().getBooleanIfExists("settings.create-suspicious-blocks", false));
+        Boolean exclusionListStatus = PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enable-item-exclusion-list", false);
+        List<String> exclusionList = PurpurExtras.getPurpurConfig().getList("settings.suspicious-blocks.item-exclusion-list", List.of("SHULKER_BOX"));
+        return susBlocksEnabled;
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onInteractWithSusBlock(PlayerInteractEvent event) {
+    public void onInteractWithSusBlock(PlayerInteractEvent event, Boolean exclusionListStatus, List<String> exclusionList) {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         Player player = event.getPlayer();
         if (!player.isSneaking()) return;
         Block block = event.getClickedBlock();
         if (block == null) return;
+        if (exclusionListStatus && exclusionList.contains(event.getItem().getType().name())) return;
         if (block.getType() != Material.SAND && block.getType() != Material.GRAVEL) return;
         ItemStack itemStack = event.getItem();
         if (itemStack == null) return;


### PR DESCRIPTION
Fixes #79 
Makes it so that touching a block while holding a certain item specified in the `item-exclusion-list` prevents it from getting turned to its suspicious version
Also implemented a small config migration for the old value of the `create-suspicious-blocks` option gets transferred to the new configuration block and the old one gets removed