### PR TITLE
Resolution for Issue #98 In PurpurMC/PurpurExtras; Adjusted Enchanted Book Handling in the Grindstone

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/GrindstoneEnchantsBooksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/GrindstoneEnchantsBooksModule.java
@@ -55,12 +55,12 @@ public class GrindstoneEnchantsBooksModule implements PurpurExtrasModule, Listen
         GrindstoneInventory grindstoneInventory = event.getInventory();
 
         ItemStack lowerItem = grindstoneInventory.getLowerItem();
-        if (lowerItem != null && !lowerItem.getType().isEmpty()) {
+        if (lowerItem != null && !lowerItem.getType().isAir()) {
             return; // lower slot is not empty, do nothing
         }
 
         ItemStack upperItem = grindstoneInventory.getUpperItem();
-        if (upperItem == null || upperItem.getType().isEmpty()) {
+        if (upperItem == null || upperItem.getType().isAir()) {
             return; // upper slot is empty, do nothing
         }
 


### PR DESCRIPTION
Adjusted the way that Enchanted books are handled in the grindstone. Instead of giving back an enchanted book with the same enchantment that player's tried to remove, it allows for players to receive back a blank unenchanted book to allow reuse of books.

The only code modified was within this file. I have tested on my personal server and it works as intended.