### PR TITLE
Add reach-through option

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/PurpurConfig.java
+++ b/src/main/java/org/purpurmc/purpurextras/PurpurConfig.java
@@ -30,7 +30,7 @@ public class PurpurConfig {
         }
     }
 
-    public boolean getBooleanIfExists(String path, boolean def) {
+    public boolean getBooleanAndRemove(String path, boolean def) {
         if (config.isSet(path)) {
             Boolean setting = config.getBoolean(path, def);
             config.set(path, null);

--- a/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/CreateSusBlocksModule.java
@@ -57,7 +57,7 @@ public class CreateSusBlocksModule implements PurpurExtrasModule, Listener {
         } catch (IllegalArgumentException e) {
             this.messageType = MessageType.CHAT;
         }
-        return PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enabled", PurpurExtras.getPurpurConfig().getBooleanIfExists("settings.create-suspicious-blocks", false));
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.suspicious-blocks.enabled", PurpurExtras.getPurpurConfig().getBooleanAndRemove("settings.create-suspicious-blocks", false));
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/InvisibleItemFrameModule.java
@@ -1,5 +1,6 @@
 package org.purpurmc.purpurextras.modules;
 
+import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
@@ -7,10 +8,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
+import org.purpurmc.purpurextras.PurpurConfig;
 import org.purpurmc.purpurextras.PurpurExtras;
 
 /**
@@ -19,7 +22,17 @@ import org.purpurmc.purpurextras.PurpurExtras;
  */
 public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
 
-    protected InvisibleItemFrameModule() {}
+    private ToggleClickType clickType;
+
+    protected InvisibleItemFrameModule() {
+        String clickString = PurpurExtras.getPurpurConfig().getString("settings.blocks.invisible-frames.click-type", "LEFT");
+        try {
+            clickType = ToggleClickType.valueOf(clickString.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            PurpurExtras.getInstance().getSLF4JLogger().warn("{} is not a valid choice for click type! Please use the values 'RIGHT' or 'LEFT'! Defaulting to 'LEFT'", clickString);
+            clickType = ToggleClickType.LEFT;
+        }
+    }
 
     private final Permission invisFramePermission = new Permission(
             "purpurextras.invisibleframes",
@@ -36,23 +49,75 @@ public class InvisibleItemFrameModule implements PurpurExtrasModule, Listener {
     @Override
     public boolean shouldEnable() {
         registerPermissions(invisFramePermission);
-        return PurpurExtras.getPurpurConfig().getBoolean("settings.blocks.shift-right-click-for-invisible-item-frames", false);
+        PurpurConfig config = PurpurExtras.getPurpurConfig();
+        migrateConfig(config);
+        return config.getBoolean("settings.blocks.invisible-frames.enabled", false);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onItemFrameInteract(PlayerInteractEntityEvent event){
+    public void onItemFrameInteract(PlayerInteractEntityEvent event) {
         if (event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        if (clickType.equals(ToggleClickType.LEFT)) return;
 
         Player player = event.getPlayer();
         if (!player.isSneaking()) return;
 
         Entity entity = event.getRightClicked();
         if (!(entity instanceof ItemFrame itemFrame)) return;
-        if (itemFrame.getItem().getType().equals(Material.AIR)) return;
-        if (!player.hasPermission(invisFramePermission)) return;
-
+        if (!passesChecks(player, itemFrame)) return;
         event.setCancelled(true);
+        toggleFrame(itemFrame);
+    }
+
+
+    /**
+     * This handles the attack when the item frame is invisible.
+     * FOR SOME REASON the other event doesn't fire when the item frame is hit in this state
+     */
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemFrameAttack(EntityDamageByEntityEvent event) {
+        if (clickType.equals(ToggleClickType.RIGHT)) return;
+        if (!(event.getEntity() instanceof ItemFrame itemFrame)) return;
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!player.isSneaking()) return;
+        if (!passesChecks(player, itemFrame)) return;
+        event.setCancelled(true);
+        toggleFrame(itemFrame);
+    }
+
+    /**
+     * Handles when the item frame is invisible, 'cause apparently it can't handle the visible one as well for some reason.
+     */
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemFrameAttack(PrePlayerAttackEntityEvent event) {
+        Player player = event.getPlayer();
+        if (!player.isSneaking()) return;
+        if (clickType.equals(ToggleClickType.RIGHT)) return;
+        if (!(event.getAttacked() instanceof ItemFrame itemFrame)) return;
+        if (!passesChecks(player, itemFrame)) return;
+        event.setCancelled(true);
+        toggleFrame(itemFrame);
+    }
+
+    private boolean passesChecks(Player player, ItemFrame itemFrame) {
+        if (itemFrame.getItem().getType().equals(Material.AIR)) return false;
+        return player.hasPermission(invisFramePermission);
+    }
+
+    private void toggleFrame(ItemFrame itemFrame) {
         itemFrame.setVisible(!itemFrame.isVisible());
         itemFrame.setFixed(!itemFrame.isFixed());
+    }
+
+    public enum ToggleClickType {
+        LEFT,
+        RIGHT;
+    }
+
+    private void migrateConfig(PurpurConfig config) {
+        boolean previousValue = config.getBooleanAndRemove("settings.blocks.shift-right-click-for-invisible-item-frames", false);
+        config.getBoolean("settings.blocks.invisible-frames.enabled", previousValue);
     }
 }

--- a/src/main/java/org/purpurmc/purpurextras/modules/ReachThroughModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/ReachThroughModule.java
@@ -1,0 +1,104 @@
+package org.purpurmc.purpurextras.modules;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Container;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.Directional;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.material.Attachable;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+import java.util.HashSet;
+
+public class ReachThroughModule implements PurpurExtrasModule, Listener {
+    private boolean bypassEmptyFrames, bypassFilledFrames, bypassUnwaxedSigns, bypassWaxedSigns, bypassPaintings;
+
+    private final HashSet<EntityType> passableEntities = new HashSet<>();
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        if (bypassEmptyFrames || bypassFilledFrames) {
+            passableEntities.add(EntityType.ITEM_FRAME);
+            passableEntities.add(EntityType.GLOW_ITEM_FRAME);
+        }
+        if (bypassPaintings) passableEntities.add(EntityType.PAINTING);
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityInteract(PlayerInteractEntityEvent interactEntityEvent) {
+        if (interactEntityEvent.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        Player player = interactEntityEvent.getPlayer();
+        if (player.isSneaking()) return;
+        Entity entityClicked = interactEntityEvent.getRightClicked();
+        if (!passableEntities.contains(entityClicked.getType())) return;
+        if (!(entityClicked instanceof Attachable attachableBlock)) return;
+        if ((entityClicked instanceof ItemFrame itemFrame) && !itemFramePassthroughEnabled(itemFrame)) return;
+        Inventory containerInv = getContainerInventory(attachableBlock.getAttachedFace(), entityClicked.getLocation().toBlockLocation());
+        if (containerInv == null) return;
+        interactEntityEvent.setCancelled(true);
+        player.openInventory(containerInv);
+
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInteractEvent(PlayerInteractEvent interactEvent){
+        if (!bypassWaxedSigns && !bypassUnwaxedSigns) return;
+        Player player = interactEvent.getPlayer();
+        Block blockClicked = interactEvent.getClickedBlock();
+        if (interactEvent.getHand() == null || interactEvent.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+        if (player.isSneaking()) return;
+        if (blockClicked == null) return;
+        if (!(blockClicked.getState() instanceof Sign signClicked)) return;
+        if (!signPassthroughEnabled(signClicked)) return;
+        if (!(blockClicked.getBlockData() instanceof Directional directionalBlock)) return;
+        BlockFace face = directionalBlock.getFacing().getOppositeFace();
+        Inventory inventoryClicked = getContainerInventory(face, blockClicked.getLocation());
+        if (inventoryClicked == null) return;
+        interactEvent.setCancelled(true);
+        player.openInventory(inventoryClicked);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        bypassEmptyFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.empty", false);
+        bypassFilledFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.filled", false);
+        bypassPaintings = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.paintings", false);
+        bypassUnwaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.unwaxed", false);
+        bypassWaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.waxed", false);
+        return bypassEmptyFrames || bypassFilledFrames || bypassPaintings || bypassUnwaxedSigns || bypassWaxedSigns;
+    }
+
+    private Inventory getContainerInventory(BlockFace face, Location location) {
+        int attachedXOffset = face.getModX();
+        int attachedYOffset = face.getModY();
+        int attachedZOffset = face.getModZ();
+        Location attachedBlockLocation = location.add(attachedXOffset, attachedYOffset, attachedZOffset);
+        Block blockAtLocation = attachedBlockLocation.getBlock();
+        if (!(blockAtLocation.getState() instanceof Container containerBlock)) return null;
+        return containerBlock.getInventory();
+    }
+
+    private boolean signPassthroughEnabled(Sign sign){
+        if (sign.isWaxed() && !bypassWaxedSigns) return false;
+        if (!sign.isWaxed() && !bypassUnwaxedSigns) return false;
+        return true;
+    }
+
+    private boolean itemFramePassthroughEnabled(ItemFrame itemFrame){
+        if (itemFrame.getItem().isEmpty() && !bypassEmptyFrames) return false;
+        return true;
+    }
+}

--- a/src/main/java/org/purpurmc/purpurextras/modules/ReachThroughModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/ReachThroughModule.java
@@ -4,10 +4,28 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Statistic;
-import org.bukkit.block.*;
-import org.bukkit.block.data.BlockData;
+import org.bukkit.block.Barrel;
+import org.bukkit.block.BlastFurnace;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.BrewingStand;
+import org.bukkit.block.Chest;
+import org.bukkit.block.Container;
+import org.bukkit.block.Crafter;
+import org.bukkit.block.Dispenser;
+import org.bukkit.block.Dropper;
+import org.bukkit.block.Furnace;
+import org.bukkit.block.Hopper;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.block.Sign;
+import org.bukkit.block.Smoker;
 import org.bukkit.block.data.Directional;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Piglin;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -16,6 +34,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.material.Attachable;
 import org.purpurmc.purpurextras.PurpurExtras;
 
@@ -23,37 +42,35 @@ import java.util.HashSet;
 import java.util.List;
 
 public class ReachThroughModule implements PurpurExtrasModule, Listener {
-    private boolean bypassEmptyFrames, bypassFilledFrames, bypassUnwaxedSigns, bypassWaxedSigns, bypassPaintings,
+    private boolean reachThroughEmptyFrames, reachThroughFilledFrames, reachThroughSigns, reachThroughPaintings,
             openBlockedContainers, triggerPiglinAggro, incrementStatistics;
 
     private final HashSet<EntityType> passableEntities = new HashSet<>();
 
     public ReachThroughModule() {
-        }
+    }
 
     @Override
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        if (bypassEmptyFrames || bypassFilledFrames) {
+        if (reachThroughEmptyFrames || reachThroughFilledFrames) {
             passableEntities.add(EntityType.ITEM_FRAME);
             passableEntities.add(EntityType.GLOW_ITEM_FRAME);
         }
-        if (bypassPaintings) passableEntities.add(EntityType.PAINTING);
+        if (reachThroughPaintings) passableEntities.add(EntityType.PAINTING);
         openBlockedContainers = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.options.open-blocked-containers", false);
         triggerPiglinAggro = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.options.trigger-piglin-aggro", true);
         incrementStatistics = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.options.increment-statistics", true);
-
     }
 
     @Override
     public boolean shouldEnable() {
-        bypassEmptyFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.empty", false);
-        bypassFilledFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.filled", false);
-        bypassPaintings = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.paintings", false);
-        bypassUnwaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.unwaxed", false);
-        bypassWaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.waxed", false);
-        return bypassEmptyFrames || bypassFilledFrames || bypassPaintings || bypassUnwaxedSigns || bypassWaxedSigns;
+        reachThroughEmptyFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.empty", false);
+        reachThroughFilledFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.filled", false);
+        reachThroughPaintings = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.paintings", false);
+        reachThroughSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.waxed", false);
+        return reachThroughEmptyFrames || reachThroughFilledFrames || reachThroughPaintings || reachThroughSigns;
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -61,142 +78,148 @@ public class ReachThroughModule implements PurpurExtrasModule, Listener {
         if (interactEntityEvent.getHand().equals(EquipmentSlot.OFF_HAND)) return;
         Player player = interactEntityEvent.getPlayer();
         if (player.isSneaking()) return;
+
         Entity entityClicked = interactEntityEvent.getRightClicked();
         if (!passableEntities.contains(entityClicked.getType())) return;
         if (!(entityClicked instanceof Attachable attachableBlock)) return;
-        if ((entityClicked instanceof ItemFrame itemFrame) && !itemFramePassthroughEnabled(itemFrame)) return;
+        if ((entityClicked instanceof ItemFrame itemFrame) && !canReachThroughItemFrame(itemFrame)) return;
+
         BlockFace face = attachableBlock.getAttachedFace();
-        Container container = getContainer(face, entityClicked.getLocation().toBlockLocation());
-        if (container == null) return;
-        if (!canInteractWithContainer(player, container, face)) return;
-        if (!canOpenContainer(container)) return;
+        if (!openedInventory(player, getBlockFromBlockFace(face,
+                interactEntityEvent.getRightClicked().getLocation()), face)) return;
         interactEntityEvent.setCancelled(true);
-        player.openInventory(container.getInventory());
-        handleContainerTypes(player, container);
     }
 
     @EventHandler(ignoreCancelled = true)
-    public void onInteractEvent(PlayerInteractEvent interactEvent) {
-        if (!bypassWaxedSigns && !bypassUnwaxedSigns) return;
+    public void onSignInteract(PlayerInteractEvent interactEvent) {
+        if (!reachThroughSigns) return;
+        if (interactEvent.getHand() == null || interactEvent.getHand().equals(EquipmentSlot.OFF_HAND) || interactEvent.getAction().isLeftClick())
+            return;
         Player player = interactEvent.getPlayer();
         Block blockClicked = interactEvent.getClickedBlock();
-        if (interactEvent.getHand() == null || interactEvent.getHand().equals(EquipmentSlot.OFF_HAND)) return;
         if (player.isSneaking()) return;
         if (blockClicked == null) return;
-        if (!(blockClicked.getState() instanceof Sign signClicked)) return;
-        if (!signPassthroughEnabled(signClicked)) return;
-        if (!(blockClicked.getBlockData() instanceof Directional directionalBlock)) return;
+        if (!(blockClicked.getState() instanceof Sign signClicked) || !(blockClicked.getBlockData() instanceof Directional directionalBlock))
+            return;
+        if (!signClicked.isWaxed()) return;
         BlockFace face = directionalBlock.getFacing().getOppositeFace();
-        Container container = getContainer(face, blockClicked.getLocation());
-        if (container == null) return;
-        if (!canInteractWithContainer(player, container, face)) return;
-        if (!canOpenContainer(container)) return;
+        if (!openedInventory(player, getBlockFromBlockFace(face,
+                blockClicked.getLocation()), face)) return;
         interactEvent.setCancelled(true);
-        player.openInventory(container.getInventory());
-        handleContainerTypes(player, container);
     }
 
-    @SuppressWarnings("UnstableApiUsage")
-    private boolean canInteractWithContainer(Player player, Container containerBlock, BlockFace attachedFace) {
-        Block block = containerBlock.getBlock();
-        PlayerInteractEvent newEvent = new PlayerInteractEvent(player, Action.RIGHT_CLICK_BLOCK, player.getInventory().getItemInMainHand(), block, attachedFace, EquipmentSlot.HAND);
+    @SuppressWarnings({"UnstableApiUsage", "BooleanMethodIsAlwaysInverted"})
+    private boolean openedInventory(Player player, Block block, BlockFace face) {
+        PlayerInteractEvent newEvent = new PlayerInteractEvent(player, Action.RIGHT_CLICK_BLOCK,
+                player.getInventory().getItemInMainHand(), block, face, EquipmentSlot.HAND);
         Bukkit.getServer().getPluginManager().callEvent(newEvent);
-        return !newEvent.useInteractedBlock().equals(Event.Result.DENY);
+        if (newEvent.useInteractedBlock().equals(Event.Result.DENY)) return false;
+        if (block.getType().equals(Material.ENDER_CHEST)) {
+            openEnderchest(player);
+            return true;
+        }
+
+        BlockState state = block.getState(true);
+        if (!(state instanceof Container container)) return false;
+        if (containerIsBlocked(container)) return false;
+
+        InventoryView openedInventory = player.openInventory(container.getInventory());
+        handleContainerBehavior(openedInventory, newEvent, player, container);
+        return true;
     }
 
-    private boolean canOpenContainer(Container container) {
+
+    private boolean containerIsBlocked(Container container) {
         if (openBlockedContainers) return true;
         if (container instanceof ShulkerBox shulkerBox) {
             Directional directional = (Directional) shulkerBox.getBlockData();
             BlockFace blockFace = directional.getFacing();
             Location facingBlock = shulkerBox.getLocation().add(blockFace.getModX(), blockFace.getModY(), blockFace.getModZ()).toBlockLocation();
-            return facingBlock.getBlock().getType().isAir();
+            return !facingBlock.getBlock().getType().isAir();
         }
-        if (container instanceof Chest) {
-            Location location = container.getLocation().add(0, 1, 0);
-            return !location.getBlock().isSuffocating();
+        if (container instanceof Chest chest) {
+            return chest.isBlocked();
         }
-        return true;
+        return false;
     }
 
-    private Container getContainer(BlockFace face, Location location) {
+    private Block getBlockFromBlockFace(BlockFace face, Location location) {
         int attachedXOffset = face.getModX();
         int attachedYOffset = face.getModY();
         int attachedZOffset = face.getModZ();
         Location attachedBlockLocation = location.add(attachedXOffset, attachedYOffset, attachedZOffset);
-        Block blockAtLocation = attachedBlockLocation.getBlock();
-        if (!(blockAtLocation.getState() instanceof Container containerBlock)) return null;
-        return containerBlock;
+        return attachedBlockLocation.getBlock();
+    }
+
+
+    private void handleContainerBehavior(InventoryView inventoryView, PlayerInteractEvent newInteractEvent,
+                                         Player player, Container container) {
+        Block block = container.getBlock();
+        if (!player.getOpenInventory().equals(inventoryView)) {
+            newInteractEvent.setCancelled(true);
+            return;
+        }
+        if (block.getType().equals(Material.TRAPPED_CHEST)) {
+            aggroPiglins(player);
+            increment(player, Statistic.TRAPPED_CHEST_TRIGGERED);
+            return;
+        }
+        switch (container) {
+            case Barrel ignored -> {
+                aggroPiglins(player);
+                increment(player, Statistic.OPEN_BARREL);
+            }
+            case Chest ignored -> {
+                aggroPiglins(player);
+                increment(player, Statistic.CHEST_OPENED);
+            }
+            case ShulkerBox ignored -> {
+                aggroPiglins(player);
+                increment(player, Statistic.SHULKER_BOX_OPENED);
+            }
+            case BlastFurnace ignored -> increment(player, Statistic.INTERACT_WITH_BLAST_FURNACE);
+            case BrewingStand ignored -> increment(player, Statistic.BREWINGSTAND_INTERACTION);
+            case Crafter ignored -> {
+                //There is no statistic for this??
+            }
+            case Dispenser ignored -> increment(player, Statistic.DISPENSER_INSPECTED);
+            case Dropper ignored -> increment(player, Statistic.DROPPER_INSPECTED);
+            case Smoker ignored -> increment(player, Statistic.INTERACT_WITH_SMOKER);
+            case Furnace ignored -> increment(player, Statistic.FURNACE_INTERACTION);
+            case Hopper ignored -> increment(player, Statistic.HOPPER_INSPECTED);
+            default -> {
+            }
+        }
     }
 
     private void aggroPiglins(Player player) {
+        if (!triggerPiglinAggro) return;
         List<Entity> nearbyEntities = player.getNearbyEntities(15, 3, 15);
+        Location playerLocation = player.getLocation().toBlockLocation();
         for (Entity entity : nearbyEntities) {
             if (!(entity instanceof Piglin piglin)) continue;
             if (!piglin.hasLineOfSight(player)) continue;
+            if (piglin.getLocation().distance(playerLocation) > 15) continue;
             piglin.setMemory(MemoryKey.ANGRY_AT, player.getUniqueId());
         }
     }
 
-
-    private void handleContainerTypes(Player player, Container container) {
-        Block block = container.getBlock();
-        if (block.getType().equals(Material.TRAPPED_CHEST)) {
-            if (triggerPiglinAggro) aggroPiglins(player);
-            if (incrementStatistics) player.incrementStatistic(Statistic.TRAPPED_CHEST_TRIGGERED);
-        }
-        BlockData blockData = container.getBlock().getBlockData();
-        if (blockData instanceof EnderChest) if (incrementStatistics) player.incrementStatistic(Statistic.ENDERCHEST_OPENED);
-
-        switch (container) {
-            case Barrel ignored -> {
-                if (triggerPiglinAggro) aggroPiglins(player);
-                if (incrementStatistics) player.incrementStatistic(Statistic.OPEN_BARREL);
-            }
-            case BlastFurnace ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.INTERACT_WITH_BLAST_FURNACE);
-            }
-            case BrewingStand ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.BREWINGSTAND_INTERACTION);
-            }
-            case Chest ignored -> {
-                if (triggerPiglinAggro) aggroPiglins(player);
-                if (incrementStatistics) player.incrementStatistic(Statistic.CHEST_OPENED);
-            }
-            case Crafter ignored -> {
-                //There is no statistic for this??
-            }
-            case Dispenser ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.DISPENSER_INSPECTED);
-            }
-            case Dropper ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.DROPPER_INSPECTED);
-            }
-            case Smoker ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.INTERACT_WITH_SMOKER);
-            }
-            case Furnace ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.FURNACE_INTERACTION);
-            }
-            case Hopper ignored -> {
-                if (incrementStatistics) player.incrementStatistic(Statistic.HOPPER_INSPECTED);
-            }
-            case ShulkerBox ignored -> {
-                if (triggerPiglinAggro) aggroPiglins(player);
-                if (incrementStatistics) player.incrementStatistic(Statistic.SHULKER_BOX_OPENED);
-            }
-            default -> {}
+    private boolean canReachThroughItemFrame(ItemFrame itemFrame) {
+        if (itemFrame.getItem().isEmpty()) {
+            return reachThroughEmptyFrames;
+        } else {
+            return reachThroughFilledFrames;
         }
     }
 
-    private boolean signPassthroughEnabled(Sign sign) {
-        if (sign.isWaxed() && !bypassWaxedSigns) return false;
-        if (!sign.isWaxed() && !bypassUnwaxedSigns) return false;
-        return true;
+    private void increment(Player player, Statistic statistic) {
+        if (incrementStatistics) player.incrementStatistic(statistic);
     }
 
-    private boolean itemFramePassthroughEnabled(ItemFrame itemFrame) {
-        if (itemFrame.getItem().isEmpty() && !bypassEmptyFrames) return false;
-        return true;
+    private void openEnderchest(Player player) {
+        InventoryView view = player.openInventory(player.getEnderChest());
+        if (!player.getOpenInventory().equals(view)) return;
+        increment(player, Statistic.ENDERCHEST_OPENED);
     }
+
 }

--- a/src/main/java/org/purpurmc/purpurextras/modules/ReachThroughModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/ReachThroughModule.java
@@ -2,15 +2,13 @@ package org.purpurmc.purpurextras.modules;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.block.Container;
-import org.bukkit.block.Sign;
+import org.bukkit.Material;
+import org.bukkit.Statistic;
+import org.bukkit.block.*;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.*;
+import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,11 +20,16 @@ import org.bukkit.material.Attachable;
 import org.purpurmc.purpurextras.PurpurExtras;
 
 import java.util.HashSet;
+import java.util.List;
 
 public class ReachThroughModule implements PurpurExtrasModule, Listener {
-    private boolean bypassEmptyFrames, bypassFilledFrames, bypassUnwaxedSigns, bypassWaxedSigns, bypassPaintings;
+    private boolean bypassEmptyFrames, bypassFilledFrames, bypassUnwaxedSigns, bypassWaxedSigns, bypassPaintings,
+            openBlockedContainers, triggerPiglinAggro, incrementStatistics;
 
     private final HashSet<EntityType> passableEntities = new HashSet<>();
+
+    public ReachThroughModule() {
+        }
 
     @Override
     public void enable() {
@@ -37,6 +40,20 @@ public class ReachThroughModule implements PurpurExtrasModule, Listener {
             passableEntities.add(EntityType.GLOW_ITEM_FRAME);
         }
         if (bypassPaintings) passableEntities.add(EntityType.PAINTING);
+        openBlockedContainers = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.options.open-blocked-containers", false);
+        triggerPiglinAggro = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.options.trigger-piglin-aggro", true);
+        incrementStatistics = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.options.increment-statistics", true);
+
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        bypassEmptyFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.empty", false);
+        bypassFilledFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.filled", false);
+        bypassPaintings = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.paintings", false);
+        bypassUnwaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.unwaxed", false);
+        bypassWaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.waxed", false);
+        return bypassEmptyFrames || bypassFilledFrames || bypassPaintings || bypassUnwaxedSigns || bypassWaxedSigns;
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -52,9 +69,10 @@ public class ReachThroughModule implements PurpurExtrasModule, Listener {
         Container container = getContainer(face, entityClicked.getLocation().toBlockLocation());
         if (container == null) return;
         if (!canInteractWithContainer(player, container, face)) return;
+        if (!canOpenContainer(container)) return;
         interactEntityEvent.setCancelled(true);
         player.openInventory(container.getInventory());
-
+        handleContainerTypes(player, container);
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -72,18 +90,10 @@ public class ReachThroughModule implements PurpurExtrasModule, Listener {
         Container container = getContainer(face, blockClicked.getLocation());
         if (container == null) return;
         if (!canInteractWithContainer(player, container, face)) return;
+        if (!canOpenContainer(container)) return;
         interactEvent.setCancelled(true);
         player.openInventory(container.getInventory());
-    }
-
-    @Override
-    public boolean shouldEnable() {
-        bypassEmptyFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.empty", false);
-        bypassFilledFrames = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.item-frames.filled", false);
-        bypassPaintings = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.paintings", false);
-        bypassUnwaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.unwaxed", false);
-        bypassWaxedSigns = PurpurExtras.getPurpurConfig().getBoolean("settings.reach-through.signs.waxed", false);
-        return bypassEmptyFrames || bypassFilledFrames || bypassPaintings || bypassUnwaxedSigns || bypassWaxedSigns;
+        handleContainerTypes(player, container);
     }
 
     @SuppressWarnings("UnstableApiUsage")
@@ -94,6 +104,21 @@ public class ReachThroughModule implements PurpurExtrasModule, Listener {
         return !newEvent.useInteractedBlock().equals(Event.Result.DENY);
     }
 
+    private boolean canOpenContainer(Container container) {
+        if (openBlockedContainers) return true;
+        if (container instanceof ShulkerBox shulkerBox) {
+            Directional directional = (Directional) shulkerBox.getBlockData();
+            BlockFace blockFace = directional.getFacing();
+            Location facingBlock = shulkerBox.getLocation().add(blockFace.getModX(), blockFace.getModY(), blockFace.getModZ()).toBlockLocation();
+            return facingBlock.getBlock().getType().isAir();
+        }
+        if (container instanceof Chest) {
+            Location location = container.getLocation().add(0, 1, 0);
+            return !location.getBlock().isSuffocating();
+        }
+        return true;
+    }
+
     private Container getContainer(BlockFace face, Location location) {
         int attachedXOffset = face.getModX();
         int attachedYOffset = face.getModY();
@@ -102,6 +127,66 @@ public class ReachThroughModule implements PurpurExtrasModule, Listener {
         Block blockAtLocation = attachedBlockLocation.getBlock();
         if (!(blockAtLocation.getState() instanceof Container containerBlock)) return null;
         return containerBlock;
+    }
+
+    private void aggroPiglins(Player player) {
+        List<Entity> nearbyEntities = player.getNearbyEntities(15, 3, 15);
+        for (Entity entity : nearbyEntities) {
+            if (!(entity instanceof Piglin piglin)) continue;
+            if (!piglin.hasLineOfSight(player)) continue;
+            piglin.setMemory(MemoryKey.ANGRY_AT, player.getUniqueId());
+        }
+    }
+
+
+    private void handleContainerTypes(Player player, Container container) {
+        Block block = container.getBlock();
+        if (block.getType().equals(Material.TRAPPED_CHEST)) {
+            if (triggerPiglinAggro) aggroPiglins(player);
+            if (incrementStatistics) player.incrementStatistic(Statistic.TRAPPED_CHEST_TRIGGERED);
+        }
+        BlockData blockData = container.getBlock().getBlockData();
+        if (blockData instanceof EnderChest) if (incrementStatistics) player.incrementStatistic(Statistic.ENDERCHEST_OPENED);
+
+        switch (container) {
+            case Barrel ignored -> {
+                if (triggerPiglinAggro) aggroPiglins(player);
+                if (incrementStatistics) player.incrementStatistic(Statistic.OPEN_BARREL);
+            }
+            case BlastFurnace ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.INTERACT_WITH_BLAST_FURNACE);
+            }
+            case BrewingStand ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.BREWINGSTAND_INTERACTION);
+            }
+            case Chest ignored -> {
+                if (triggerPiglinAggro) aggroPiglins(player);
+                if (incrementStatistics) player.incrementStatistic(Statistic.CHEST_OPENED);
+            }
+            case Crafter ignored -> {
+                //There is no statistic for this??
+            }
+            case Dispenser ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.DISPENSER_INSPECTED);
+            }
+            case Dropper ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.DROPPER_INSPECTED);
+            }
+            case Smoker ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.INTERACT_WITH_SMOKER);
+            }
+            case Furnace ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.FURNACE_INTERACTION);
+            }
+            case Hopper ignored -> {
+                if (incrementStatistics) player.incrementStatistic(Statistic.HOPPER_INSPECTED);
+            }
+            case ShulkerBox ignored -> {
+                if (triggerPiglinAggro) aggroPiglins(player);
+                if (incrementStatistics) player.incrementStatistic(Statistic.SHULKER_BOX_OPENED);
+            }
+            default -> {}
+        }
     }
 
     private boolean signPassthroughEnabled(Sign sign) {


### PR DESCRIPTION
Adds an option that allows users to reach-through tile entities and open a container behind it

Configuration options for:
- Item frames
  - Filled
  - Empty
- Signs
  - Waxed
  - Unwaxed
- Paintings

Note, the current implementation does end up bypassing some claim plugins, as 'interact' is handled differently in a lot of claim plugins and doesn't always cancel the event. 