### PR TITLE
Add a join full server module.

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/JoinFullServerModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/JoinFullServerModule.java
@@ -1,0 +1,67 @@
+package org.purpurmc.purpurextras.modules;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+public class JoinFullServerModule implements PurpurExtrasModule, Listener {
+
+    private final Permission joinFullServerPermission = new Permission(
+            "purpurextras.joinfullserver",
+            "Allows a player to bypass the player limit",
+            PermissionDefault.OP
+    );
+
+    private final Permission legacyJoinFullServerPermission = new Permission(
+            "purpur.joinfullserver",
+            "Allows a player to bypass the player limit (legacy alias)",
+            PermissionDefault.OP
+    );
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+
+        if (legacyPermissionEnabled()) {
+            plugin.getLogger().warning("The \"legacy-permission\" setting is enabled.");
+            plugin.getLogger().warning("The \"purpur.joinfullserver\" permission node is deprecated and will be removed in a future release.");
+            plugin.getLogger().warning("Please migrate to the \"purpurextras.joinfullserver\" permission node.");
+        }
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        if (legacyPermissionEnabled()) {
+            registerPermissions(joinFullServerPermission, legacyJoinFullServerPermission);
+        } else {
+            registerPermissions(joinFullServerPermission);
+        }
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.enabled", false);
+    }
+
+    private boolean legacyPermissionEnabled() {
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.legacy-permission", false);
+    }
+
+    private boolean hasRequiredPermission(Player player) {
+        if (legacyPermissionEnabled()) {
+            return player.hasPermission(joinFullServerPermission) || player.hasPermission(legacyJoinFullServerPermission);
+        }
+        return player.hasPermission(joinFullServerPermission);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        if (event.getResult() == PlayerLoginEvent.Result.KICK_FULL) {
+            if (hasRequiredPermission(event.getPlayer())) {
+                event.allow();
+            }
+        }
+    }
+}

--- a/src/main/java/org/purpurmc/purpurextras/modules/JoinFullServerModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/JoinFullServerModule.java
@@ -1,67 +1,44 @@
 package org.purpurmc.purpurextras.modules;
 
-import org.bukkit.entity.Player;
+import io.papermc.paper.event.player.PlayerServerFullCheckEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.permissions.Permission;
-import org.bukkit.permissions.PermissionDefault;
 import org.purpurmc.purpurextras.PurpurExtras;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
 public class JoinFullServerModule implements PurpurExtrasModule, Listener {
-
-    private final Permission joinFullServerPermission = new Permission(
-            "purpurextras.joinfullserver",
-            "Allows a player to bypass the player limit",
-            PermissionDefault.OP
-    );
-
-    private final Permission legacyJoinFullServerPermission = new Permission(
-            "purpur.joinfullserver",
-            "Allows a player to bypass the player limit (legacy alias)",
-            PermissionDefault.OP
-    );
 
     @Override
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-
-        if (legacyPermissionEnabled()) {
-            plugin.getLogger().warning("The \"legacy-permission\" setting is enabled.");
-            plugin.getLogger().warning("The \"purpur.joinfullserver\" permission node is deprecated and will be removed in a future release.");
-            plugin.getLogger().warning("Please migrate to the \"purpurextras.joinfullserver\" permission node.");
-        }
     }
 
     @Override
     public boolean shouldEnable() {
-        if (legacyPermissionEnabled()) {
-            registerPermissions(joinFullServerPermission, legacyJoinFullServerPermission);
-        } else {
-            registerPermissions(joinFullServerPermission);
-        }
-        return PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.enabled", false);
-    }
-
-    private boolean legacyPermissionEnabled() {
-        return PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.legacy-permission", false);
-    }
-
-    private boolean hasRequiredPermission(Player player) {
-        if (legacyPermissionEnabled()) {
-            return player.hasPermission(joinFullServerPermission) || player.hasPermission(legacyJoinFullServerPermission);
-        }
-        return player.hasPermission(joinFullServerPermission);
+        boolean enabled = PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.enabled", false);
+        PurpurExtras.getPurpurConfig().getList("settings.join-full-server.uuids", Collections.emptyList());
+        return enabled;
     }
 
     @EventHandler(priority = EventPriority.HIGH)
-    public void onPlayerLogin(PlayerLoginEvent event) {
-        if (event.getResult() == PlayerLoginEvent.Result.KICK_FULL) {
-            if (hasRequiredPermission(event.getPlayer())) {
-                event.allow();
-            }
+    public void onServerFullCheck(PlayerServerFullCheckEvent event) {
+        UUID uuid = event.getPlayerProfile().getId();
+        if (uuid == null) {
+            return;
+        }
+
+        List<String> allowed = PurpurExtras.getPurpurConfig().getList(
+                "settings.join-full-server.uuids",
+                Collections.emptyList()
+        );
+
+        if (allowed.contains(uuid.toString())) {
+            event.allow(true);
         }
     }
 }

--- a/src/main/java/org/purpurmc/purpurextras/modules/JoinFullServerModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/JoinFullServerModule.java
@@ -1,43 +1,116 @@
 package org.purpurmc.purpurextras.modules;
 
 import io.papermc.paper.event.player.PlayerServerFullCheckEvent;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.purpurmc.purpurextras.PurpurExtras;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 public class JoinFullServerModule implements PurpurExtrasModule, Listener {
 
+    private YamlConfiguration uuidConfig;
+    private File file;
+
     @Override
     public void enable() {
         PurpurExtras plugin = PurpurExtras.getInstance();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        loadUUIDFile(plugin);
     }
 
     @Override
     public boolean shouldEnable() {
-        boolean enabled = PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.enabled", false);
-        PurpurExtras.getPurpurConfig().getList("settings.join-full-server.uuids", Collections.emptyList());
-        return enabled;
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.join-full-server.enabled", false);
+    }
+
+    private void loadUUIDFile(PurpurExtras plugin) {
+        this.file = new File(plugin.getDataFolder(), "jfs_uuids.yml");
+        boolean isNewFile = false;
+
+        try {
+            if (file.getParentFile() != null && !file.getParentFile().exists()) {
+                Files.createDirectories(file.getParentFile().toPath());
+            }
+            if (!file.exists()) {
+                Files.createFile(file.toPath());
+                isNewFile = true;
+            }
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not create the JFS UUIDs file.");
+        }
+
+        this.uuidConfig = YamlConfiguration.loadConfiguration(file);
+
+        if (isNewFile) {
+            this.uuidConfig.set("uuids", Collections.emptyList());
+            saveConfig();
+        }
+    }
+
+    public synchronized boolean addUUID(UUID uuid) {
+        if (uuid == null) return false;
+        List<String> uuids = getUUIDList();
+        String uuidStr = uuid.toString();
+
+        if (uuids.contains(uuidStr)) {
+            return false;
+        }
+
+        uuids.add(uuidStr);
+        this.uuidConfig.set("uuids", uuids);
+        return saveConfig();
+    }
+
+    public synchronized boolean removeUUID(UUID uuid) {
+        if (uuid == null) return false;
+        List<String> uuids = getUUIDList();
+        String uuidStr = uuid.toString();
+
+        if (!uuids.contains(uuidStr)) {
+            return false;
+        }
+
+        uuids.remove(uuidStr);
+        this.uuidConfig.set("uuids", uuids);
+        return saveConfig();
+    }
+
+    public boolean isAllowed(UUID uuid) {
+        if (uuid == null) return false;
+        return getUUIDList().contains(uuid.toString());
+    }
+
+    private List<String> getUUIDList() {
+        if (this.uuidConfig == null) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(this.uuidConfig.getStringList("uuids"));
+    }
+
+    private boolean saveConfig() {
+        if (this.uuidConfig == null || this.file == null) return false;
+        try {
+            this.uuidConfig.save(this.file);
+            return true;
+        } catch (IOException e) {
+            PurpurExtras.getInstance().getLogger().severe("Could not save the JFS UUIDs file.");
+            return false;
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onServerFullCheck(PlayerServerFullCheckEvent event) {
         UUID uuid = event.getPlayerProfile().getId();
-        if (uuid == null) {
-            return;
-        }
-
-        List<String> allowed = PurpurExtras.getPurpurConfig().getList(
-                "settings.join-full-server.uuids",
-                Collections.emptyList()
-        );
-
-        if (allowed.contains(uuid.toString())) {
+        if (isAllowed(uuid)) {
             event.allow(true);
         }
     }


### PR DESCRIPTION
I would like to suggest the addition of a new module that adds the ability for players with a permission node to join a full server.

The original implementation in the Purpur core has been broken for a long time (https://github.com/PurpurMC/Purpur/issues/1604). Adding this module to PurpurExtras would be an effective replacement. It is much easier to implement this feature using a plugin anyways.

The permission node for the privilege is "purpurextras.joinfullserver". However, to help ensure compatibility, players can enable the legacy permission node in the configuration file ("purpur.joinfullserver").