### PR TITLE
Add ability to customise Spawner Minecarts

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/SpawnerMinecartModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/SpawnerMinecartModule.java
@@ -1,0 +1,87 @@
+package org.purpurmc.purpurextras.modules;
+
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.SpawnerMinecart;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SpawnEggMeta;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+public class SpawnerMinecartModule implements PurpurExtrasModule, Listener {
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.spawner-minecart.enabled", false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+
+        if (!(event.getRightClicked() instanceof SpawnerMinecart spawnerMinecart)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+
+        if (item.getType() == Material.AIR) {
+            return;
+        }
+
+        EntityType spawnType = getEntityTypeFromEgg(item);
+
+        if (spawnType == null || !spawnType.isSpawnable()) {
+            return;
+        }
+
+        if (spawnerMinecart.getSpawnedType() == spawnType) {
+            return;
+        }
+
+        spawnerMinecart.setSpawnedType(spawnType);
+
+        if (player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR) {
+            item.subtract(1);
+        }
+
+        event.setCancelled(true);
+    }
+
+    private EntityType getEntityTypeFromEgg(ItemStack item) {
+        String materialName = item.getType().name();
+        if (materialName.endsWith("_SPAWN_EGG")) {
+            String entityName = materialName.substring(0, materialName.length() - 10);
+            try {
+                return EntityType.valueOf(entityName);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        if (item.getItemMeta() instanceof SpawnEggMeta eggMeta) {
+            if (eggMeta.getCustomSpawnedType() != null) {
+                return eggMeta.getCustomSpawnedType();
+            }
+            if (eggMeta.getSpawnedEntity() != null) {
+                return eggMeta.getSpawnedEntity().getEntityType();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/purpurmc/purpurextras/modules/SpawnerMinecartModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/SpawnerMinecartModule.java
@@ -27,9 +27,15 @@ public class SpawnerMinecartModule implements PurpurExtrasModule, Listener {
         return PurpurExtras.getPurpurConfig().getBoolean("settings.spawner-minecart.enabled", false);
     }
 
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+
+        if (player.getGameMode() == GameMode.SPECTATOR) {
             return;
         }
 
@@ -37,9 +43,7 @@ public class SpawnerMinecartModule implements PurpurExtrasModule, Listener {
             return;
         }
 
-        Player player = event.getPlayer();
         ItemStack item = player.getInventory().getItemInMainHand();
-
         if (item.getType() == Material.AIR) {
             return;
         }
@@ -56,7 +60,7 @@ public class SpawnerMinecartModule implements PurpurExtrasModule, Listener {
 
         spawnerMinecart.setSpawnedType(spawnType);
 
-        if (player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR) {
+        if (player.getGameMode() != GameMode.CREATIVE) {
             item.subtract(1);
         }
 
@@ -64,13 +68,8 @@ public class SpawnerMinecartModule implements PurpurExtrasModule, Listener {
     }
 
     private EntityType getEntityTypeFromEgg(ItemStack item) {
-        String materialName = item.getType().name();
-        if (materialName.endsWith("_SPAWN_EGG")) {
-            String entityName = materialName.substring(0, materialName.length() - 10);
-            try {
-                return EntityType.valueOf(entityName);
-            } catch (IllegalArgumentException ignored) {
-            }
+        if (item == null || item.getType() == Material.AIR) {
+            return null;
         }
 
         if (item.getItemMeta() instanceof SpawnEggMeta eggMeta) {
@@ -79,6 +78,15 @@ public class SpawnerMinecartModule implements PurpurExtrasModule, Listener {
             }
             if (eggMeta.getSpawnedEntity() != null) {
                 return eggMeta.getSpawnedEntity().getEntityType();
+            }
+        }
+
+        String materialName = item.getType().name();
+        if (materialName.endsWith("_SPAWN_EGG")) {
+            String entityName = materialName.substring(0, materialName.length() - 10);
+            try {
+                return EntityType.valueOf(entityName);
+            } catch (IllegalArgumentException ignored) {
             }
         }
 


### PR DESCRIPTION
I'd like to suggest adding the ability to customise Spawner Minecarts with Spawn Eggs. Currently, these entities can only be customised using commands. This module would make it much easier to use Spawner Minecarts.

The module is disabled by default, but can be enabled in the "config.yml" file.