### PR TITLE
Add ability to restrict books

### DIFF
--- a/src/main/java/org/purpurmc/purpurextras/modules/BooksModule.java
+++ b/src/main/java/org/purpurmc/purpurextras/modules/BooksModule.java
@@ -1,0 +1,38 @@
+package org.purpurmc.purpurextras.modules;
+
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerEditBookEvent;
+import org.purpurmc.purpurextras.PurpurConfig;
+import org.purpurmc.purpurextras.PurpurExtras;
+
+public class BooksModule implements PurpurExtrasModule, Listener {
+
+    private final String noPermissionMessageContent;
+
+    protected BooksModule() {
+        PurpurConfig config = PurpurExtras.getPurpurConfig();
+        this.noPermissionMessageContent = config.getString("settings.books.no-permission-message", "<red>You do not have permission to edit/sign books.");
+    }
+
+    @Override
+    public void enable() {
+        PurpurExtras plugin = PurpurExtras.getInstance();
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    public boolean shouldEnable() {
+        return PurpurExtras.getPurpurConfig().getBoolean("settings.books.enabled", false);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBookEdit(PlayerEditBookEvent event) {
+        if (!event.getPlayer().hasPermission("purpurextras.books.modify")) {
+            event.setCancelled(true);
+            event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(noPermissionMessageContent));
+        }
+    }
+}


### PR DESCRIPTION
I'd like to suggest adding a module which allows restricting the ability to edit/sign books. When this module is enabled, the "purpurextras.books.modify" permission node can be used. You can also customise the permission denied message.

This is a plugin implementation of what I found in the pull requests for Purpur: https://github.com/PurpurMC/Purpur/pull/1797

It is much easier to implement/maintain this feature through PurpurExtras. You will not need to use patch files with the core project.